### PR TITLE
Implemented escaping newlines.

### DIFF
--- a/regex-syntax/src/parser.rs
+++ b/regex-syntax/src/parser.rs
@@ -1286,8 +1286,8 @@ mod tests {
         ('\u{a000}', '\u{a48c}'), ('\u{a490}', '\u{a4c6}'),
     ];
 
-    fn p(s: &str) -> Expr { Parser::parse(s, Flags::default()).expect("does not parse") }
-    fn pf(s: &str, flags: Flags) -> Expr { Parser::parse(s, flags).expect("does not parse") }
+    fn p(s: &str) -> Expr { Parser::parse(s, Flags::default()).unwrap() }
+    fn pf(s: &str, flags: Flags) -> Expr { Parser::parse(s, flags).unwrap() }
     fn lit(c: char) -> Expr { Expr::Literal { chars: vec![c], casei: false } }
     fn liti(c: char) -> Expr { Expr::Literal { chars: vec![c], casei: true } }
     fn b<T>(v: T) -> Box<T> { Box::new(v) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,7 @@
 //!
 //! <pre class="rust">
 //! \*         literal *, works for any punctuation character: \.+*?()|[]{}^$
+//! \*         where * is newline, escapes off the newline
 //! \a         bell (\x07)
 //! \f         form feed (\x0C)
 //! \t         horizontal tab


### PR DESCRIPTION
Implementation of feature suggestion mentioned in https://github.com/rust-lang/regex/issues/107 Tests and documentation included.

I think this is a nice, ergonomic bonus; the semantics are obvious and lightweight (and similar with the Rust strings newline escape). @BurntSushi said he doesn't have any strong feelings either way. What do others think?

It allows a case that was previously illegal, so not a breaking change.
