### PR TITLE
"raw strings" link fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! full text matches an expression.
 //!
 //! This example also demonstrates the utility of
-//! [raw strings](http://doc.rust-lang.org/stable/reference.html#raw-byte-string-literals)
+//! [raw strings](https://doc.rust-lang.org/stable/reference.html#raw-string-literals)
 //! in Rust, which
 //! are just like regular strings except they are prefixed with an `r` and do
 //! not process any escape sequences. For example, `"\\d"` is the same


### PR DESCRIPTION
The "raw strings" link points to the raw byte string literals section of the docs, but it should point to the raw string literals section.