### PR TITLE
Add Index<usize> and Index<&str> to Captures

### DIFF
--- a/src/re.rs
+++ b/src/re.rs
@@ -378,6 +378,11 @@ impl Regex {
     /// assert_eq!(caps.at(1), Some("Citizen Kane"));
     /// assert_eq!(caps.at(2), Some("1941"));
     /// assert_eq!(caps.at(0), Some("'Citizen Kane' (1941)"));
+    /// // You can also access the groups by index using the Index notation.
+    /// // Note that this will panic on an invalid index.
+    /// assert_eq!(&caps[1], "Citizen Kane");
+    /// assert_eq!(&caps[2], "1941");
+    /// assert_eq!(&caps[0], "'Citizen Kane' (1941)");
     /// # }
     /// ```
     ///
@@ -396,15 +401,21 @@ impl Regex {
     /// assert_eq!(caps.name("title"), Some("Citizen Kane"));
     /// assert_eq!(caps.name("year"), Some("1941"));
     /// assert_eq!(caps.at(0), Some("'Citizen Kane' (1941)"));
+    /// // You can also access the groups by name using the Index notation.
+    /// // Note that this will panic on an invalid group name.
+    /// assert_eq!(&caps["title"], "Citizen Kane");
+    /// assert_eq!(&caps["year"], "1941");
+    /// assert_eq!(&caps[0], "'Citizen Kane' (1941)");
+    ///
     /// # }
     /// ```
     ///
     /// Here we name the capture groups, which we can access with the `name`
-    /// method. Note that the named capture groups are still accessible with
-    /// `at`.
+    /// method or the `Index` notation with a `&str`. Note that the named capture groups
+    /// are still accessible with `at` or the `Index` notation with a `usize`.
     ///
     /// The `0`th capture group is always unnamed, so it must always be
-    /// accessed with `at(0)`.
+    /// accessed with `at(0)` or `[0]`.
     pub fn captures<'t>(&self, text: &'t str) -> Option<Captures<'t>> {
         let mut caps = self.alloc_captures();
         if exec(self, &mut caps, text, 0) {


### PR DESCRIPTION
I often use regexps with non-optional capture groups and end up having to use `caps.at(3).unwrap()` or `caps.name("name").unwrap()`. This change is a quality of life improvement that allows the indexing of `Captures`, like this: `caps[3]` and `caps["name"]`. If the group does not exist, a panic is triggered.