### PR TITLE
Loosen lifetime bounds on accessing named captures via `Index`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex"
-version = "0.1.48"  #:version
+version = "0.1.49"  #:version
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/re.rs
+++ b/src/re.rs
@@ -951,6 +951,15 @@ impl<'t> Captures<'t> {
 
 /// Get a group by index.
 ///
+/// `'t` is the lifetime of the matched text.
+///
+/// The text can't outlive the `Captures` object if this method is
+/// used, because of how `Index` is defined (normally `a[i]` is part
+/// of `a` and can't outlive it); to do that, use [`at()`][]
+/// instead.
+///
+/// [`at()`]: #method.at
+///
 /// # Panics
 /// If there is no group at the given index.
 impl<'t> Index<usize> for Captures<'t> {
@@ -964,6 +973,16 @@ impl<'t> Index<usize> for Captures<'t> {
 }
 
 /// Get a group by name.
+///
+/// `'t` is the lifetime of the matched text and `'i` is the lifetime
+/// of the group name (the index).
+///
+/// The text can't outlive the `Captures` object if this method is
+/// used, because of how `Index` is defined (normally `a[i]` is part
+/// of `a` and can't outlive it); to do that, use [`name()`][]
+/// instead.
+///
+/// [`name()`]: #method.name
 ///
 /// # Panics
 /// If there is no group named by the given value.

--- a/src/re.rs
+++ b/src/re.rs
@@ -967,11 +967,11 @@ impl<'t> Index<usize> for Captures<'t> {
 ///
 /// # Panics
 /// If there is no group named by the given value.
-impl<'t> Index<&'t str> for Captures<'t> {
+impl<'t, 'i> Index<&'i str> for Captures<'t> {
 
     type Output = str;
 
-    fn index<'a>(&'a self, name: &str) -> &'a str {
+    fn index<'a>(&'a self, name: &'i str) -> &'a str {
         match self.name(name) {
             None => panic!("no group named '{}'", name),
             Some(ref s) => s,
@@ -1260,5 +1260,17 @@ mod test {
         let re = Regex::new(r"^(?P<name>.+)$").unwrap();
         let cap = re.captures("abc").unwrap();
         let _ = cap["bad name"];
+    }
+
+    #[test]
+    fn test_cap_index_lifetime() {
+        // This is a test of whether the types on `caps["..."]` are general
+        // enough.  If not, this will fail to typecheck.
+        fn inner(s: &str) -> usize {
+            let re = Regex::new(r"(?P<number>\d+)").unwrap();
+            let caps = re.captures(s).unwrap();
+            caps["number"].len()
+        }
+        assert_eq!(inner("123"), 3);
     }
 }


### PR DESCRIPTION
The current definition equates the lifetime of the strings being
matched/captured and the string used as the capture name.  The latter
is usually `'static` (string literals), which leads to confusing
[borrow-check errors][err] on reasonable-looking code.

This change declares the two lifetimes as separate; this should be a
strict increase in the set of `impl` instances, so it's a minor version
bump.

[err][]: https://gist.github.com/jld/476a13a00ad05bd99a63