### PR TITLE
Rewrite the compiler.

### DIFF
--- a/regex_macros/Cargo.toml
+++ b/regex_macros/Cargo.toml
@@ -25,7 +25,7 @@ bench = true
 
 [dependencies.regex]
 path = ".."
-version = "0.1.0"
+version = "0.1"
 features = ["pattern"]
 
 [dev-dependencies]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,28 +9,29 @@
 // except according to those terms.
 
 use std::collections::HashSet;
+use std::iter;
 
 use syntax::{Expr, Repeater, CharClass, ClassRange};
 
 use Error;
-use program::{CharRanges, Inst, InstIdx};
+use inst::{
+    EmptyLook,
+    Inst, InstIdx,
+    InstSave, InstSplit, InstEmptyLook, InstChar, InstRanges,
+};
 
 pub type Compiled = (Vec<Inst>, Vec<Option<String>>);
 
-/// A regex compiler.
-///
-/// A regex compiler is responsible for turning a regex's AST into a sequence
-/// of instructions.
+type CompileResult = Result<Hole, Error>;
+
 pub struct Compiler {
     size_limit: usize,
-    insts: Vec<Inst>,
+    insts: Vec<MaybeInst>,
     cap_names: Vec<Option<String>>,
     seen_caps: HashSet<usize>,
 }
 
 impl Compiler {
-    /// Creates a new compiler that limits the size of the regex program
-    /// to the size given (in bytes).
     pub fn new(size_limit: usize) -> Compiler {
         Compiler {
             size_limit: size_limit,
@@ -40,191 +41,342 @@ impl Compiler {
         }
     }
 
-    /// Compiles the given regex AST into a tuple of a sequence of
-    /// instructions and a sequence of capture groups, optionally named.
-    pub fn compile(mut self, ast: Expr) -> Result<Compiled, Error> {
-        self.insts.push(Inst::Save(0));
-        try!(self.c(ast));
-        self.insts.push(Inst::Save(1));
-        self.insts.push(Inst::Match);
-        Ok((self.insts, self.cap_names))
+    pub fn compile(mut self, expr: &Expr) -> Result<Compiled, Error> {
+        let hole = try!(self.c_capture(0, expr));
+        self.fill_to_next(hole);
+        self.push_compiled(Inst::Match);
+
+        let insts = self.insts.into_iter().map(|inst| inst.unwrap()).collect();
+        Ok((insts, self.cap_names))
     }
 
-    fn c(&mut self, ast: Expr) -> Result<(), Error> {
-        use program::Inst::*;
-        use program::LookInst::*;
+    fn c(&mut self, expr: &Expr) -> CompileResult {
+        use inst;
+        use syntax::Expr::*;
 
-        match ast {
-            Expr::Empty => {},
-            Expr::Literal { chars, casei } => {
-                for c in chars {
-                    if casei {
-                        try!(self.c(Expr::Class(CharClass::new(vec![
-                            ClassRange { start: c, end: c },
-                        ]).case_fold())));
-                    } else {
-                        self.push(Char(c));
-                    }
-                }
+        try!(self.check_size());
+        match *expr {
+            Empty => Ok(Hole::None),
+            Literal { ref chars, casei } => self.c_literal(chars, casei),
+            AnyChar => self.c_class(Some(('\x00', '\u{10ffff}'))),
+            AnyCharNoNL => {
+                let ranges = &[('\x00', '\x09'), ('\x0b', '\u{10ffff}')];
+                self.c_class(ranges.iter().cloned())
             }
-            Expr::AnyChar => self.push(Ranges(CharRanges::any())),
-            Expr::AnyCharNoNL => self.push(Ranges(CharRanges::any_nonl())),
-            Expr::Class(cls) => {
-                if cls.len() == 1 && cls[0].start == cls[0].end {
-                    self.push(Char(cls[0].start));
-                } else {
-                    self.push(Ranges(CharRanges::from_class(cls)));
-                }
+            Class(ref cls) => {
+                let ranges = cls.iter().map(|c| (c.start, c.end));
+                self.c_class(ranges)
             }
-            Expr::StartLine => self.push(EmptyLook(StartLine)),
-            Expr::EndLine => self.push(EmptyLook(EndLine)),
-            Expr::StartText => self.push(EmptyLook(StartText)),
-            Expr::EndText => self.push(EmptyLook(EndText)),
-            Expr::WordBoundary => self.push(EmptyLook(WordBoundary)),
-            Expr::NotWordBoundary => self.push(EmptyLook(NotWordBoundary)),
-            Expr::Group { e, i: None, name: None } => try!(self.c(*e)),
-            Expr::Group { e, i, name } => {
+            StartLine => self.c_empty_look(inst::EmptyLook::StartLine),
+            EndLine => self.c_empty_look(inst::EmptyLook::EndLine),
+            StartText => self.c_empty_look(inst::EmptyLook::StartText),
+            EndText => self.c_empty_look(inst::EmptyLook::EndText),
+            WordBoundary => self.c_empty_look(inst::EmptyLook::WordBoundary),
+            NotWordBoundary => {
+                self.c_empty_look(inst::EmptyLook::NotWordBoundary)
+            }
+            Group { ref e, i: None, name: None } => self.c(e),
+            Group { ref e, i, ref name } => {
+                // it's impossible to have a named capture without an index
                 let i = i.expect("capture index");
                 if !self.seen_caps.contains(&i) {
-                    self.cap_names.push(name);
+                    self.cap_names.push(name.clone());
                     self.seen_caps.insert(i);
                 }
-                self.push(Save(2 * i));
-                try!(self.c(*e));
-                self.push(Save(2 * i + 1));
+                self.c_capture(2 * i, e)
             }
-            Expr::Concat(es) => {
-                for e in es {
-                    try!(self.c(e));
-                }
-            }
-            Expr::Alternate(mut es) => {
-                // TODO: Don't use recursion here. ---AG
-                if es.is_empty() {
-                    return Ok(());
-                }
-                let e1 = es.remove(0);
-                if es.is_empty() {
-                    try!(self.c(e1));
-                    return Ok(());
-                }
-                let e2 = Expr::Alternate(es); // this causes recursion
+            Concat(ref es) => self.c_concat(es.iter()),
+            Alternate(ref es) => self.c_alternate(&**es),
+            Repeat { ref e, r, greedy } => self.c_repeat(e, r, greedy),
+        }
+    }
 
-                let split = self.empty_split();
-                let j1 = self.insts.len();
-                try!(self.c(e1));
-                let jmp = self.empty_jump();
-                let j2 = self.insts.len();
-                try!(self.c(e2));
-                let j3 = self.insts.len();
+    fn c_capture(&mut self, first_slot: usize, expr: &Expr) -> CompileResult {
+        let hole = self.push_hole(MaybeInst::Save { slot: first_slot });
+        self.fill_to_next(hole);
 
-                self.set_split(split, j1, j2);
-                self.set_jump(jmp, j3);
-            }
-            Expr::Repeat { e, r: Repeater::ZeroOrOne, greedy } => {
-                let split = self.empty_split();
-                let j1 = self.insts.len();
-                try!(self.c(*e));
-                let j2 = self.insts.len();
+        let hole = try!(self.c(expr));
+        self.fill_to_next(hole);
 
-                if greedy {
-                    self.set_split(split, j1, j2);
-                } else {
-                    self.set_split(split, j2, j1);
-                }
-            }
-            Expr::Repeat { e, r: Repeater::ZeroOrMore, greedy } => {
-                let j1 = self.insts.len();
-                let split = self.empty_split();
-                let j2 = self.insts.len();
-                try!(self.c(*e));
-                let jmp = self.empty_jump();
-                let j3 = self.insts.len();
+        Ok(self.push_hole(MaybeInst::Save { slot: first_slot + 1 }))
+    }
 
-                self.set_jump(jmp, j1);
-                if greedy {
-                    self.set_split(split, j2, j3);
-                } else {
-                    self.set_split(split, j3, j2);
-                }
+    fn c_literal(&mut self, chars: &[char], casei: bool) -> CompileResult {
+        assert!(!chars.is_empty());
+        if casei {
+            let mut prev_hole = Hole::None;
+            for &c in chars {
+                self.fill_to_next(prev_hole);
+                let class = CharClass::new(vec![
+                    ClassRange { start: c, end: c },
+                ]);
+                prev_hole = try!(self.c(&Expr::Class(class.case_fold())));
             }
-            Expr::Repeat { e, r: Repeater::OneOrMore, greedy } => {
-                let j1 = self.insts.len();
-                try!(self.c(*e));
-                let split = self.empty_split();
-                let j2 = self.insts.len();
+            Ok(prev_hole)
+        } else {
+            let mut prev_hole = Hole::None;
+            for &c in chars {
+                self.fill_to_next(prev_hole);
+                prev_hole = self.push_hole(MaybeInst::Char { c: c });
+            }
+            Ok(prev_hole)
+        }
+    }
 
-                if greedy {
-                    self.set_split(split, j1, j2);
-                } else {
-                    self.set_split(split, j2, j1);
-                }
+    fn c_class<I>(&mut self, ranges: I) -> CompileResult
+            where I: IntoIterator<Item=(char, char)> {
+        let ranges: Vec<(char, char)> = ranges.into_iter().collect();
+        Ok(if ranges.len() == 1 && ranges[0].0 == ranges[0].1 {
+            self.push_hole(MaybeInst::Char { c: ranges[0].0 })
+        } else {
+            self.push_hole(MaybeInst::Ranges { ranges: ranges })
+        })
+    }
+
+    fn c_empty_look(&mut self, look: EmptyLook) -> CompileResult {
+        Ok(self.push_hole(MaybeInst::EmptyLook { look: look }))
+    }
+
+    fn c_concat<'a, I>(&mut self, exprs: I) -> CompileResult
+            where I: IntoIterator<Item=&'a Expr> {
+        let mut prev_hole = Hole::None;
+        for e in exprs {
+            self.fill_to_next(prev_hole);
+            prev_hole = try!(self.c(e));
+        }
+        Ok(prev_hole)
+    }
+
+    fn c_alternate(&mut self, exprs: &[Expr]) -> CompileResult {
+        assert!(exprs.len() >= 2, "alternates must have at least 2 exprs");
+        let mut holes = vec![];
+        for e in &exprs[0..exprs.len() - 1] {
+            let split = self.push_split_hole();
+            let goto1 = self.insts.len();
+            holes.push(try!(self.c(e)));
+            let goto2 = self.insts.len();
+            self.fill_split(split, Some(goto1), Some(goto2));
+        }
+        holes.push(try!(self.c(&exprs[exprs.len() - 1])));
+        Ok(Hole::Many(holes))
+    }
+
+    fn c_repeat(
+        &mut self,
+        expr: &Expr,
+        kind: Repeater,
+        greedy: bool,
+    ) -> CompileResult {
+        match kind {
+            Repeater::ZeroOrOne => self.c_repeat_zero_or_one(expr, greedy),
+            Repeater::ZeroOrMore => self.c_repeat_zero_or_more(expr, greedy),
+            Repeater::OneOrMore => self.c_repeat_one_or_more(expr, greedy),
+            Repeater::Range { min, max: None } => {
+                self.c_repeat_range_min_or_more(expr, greedy, min)
             }
-            Expr::Repeat {
-                e,
-                r: Repeater::Range { min, max: None },
-                greedy,
-            } => {
-                let e = *e;
-                for _ in 0..min {
-                    try!(self.c(e.clone()));
-                }
-                try!(self.c(Expr::Repeat {
-                    e: Box::new(e),
-                    r: Repeater::ZeroOrMore,
-                    greedy: greedy,
-                }));
+            Repeater::Range { min, max: Some(max) } => {
+                self.c_repeat_range(expr, greedy, min, max)
             }
-            Expr::Repeat {
-                e,
-                r: Repeater::Range { min, max: Some(max) },
-                greedy,
-            } => {
-                let e = *e;
-                for _ in 0..min {
-                    try!(self.c(e.clone()));
-                }
-                // It is much simpler to compile, e.g., `a{2,5}` as:
-                //
-                //     aaa?a?a?
-                //
-                // But you end up with a sequence of instructions like this:
-                //
-                //     0: 'a'
-                //     1: 'a',
-                //     2: split(3, 4)
-                //     3: 'a'
-                //     4: split(5, 6)
-                //     5: 'a'
-                //     6: split(7, 8)
-                //     7: 'a'
-                //     8: MATCH
-                //
-                // This is *incredibly* inefficient because the splits end
-                // up forming a chain. Given a much larger number than `5`,
-                // it is easy cause perverse behavior in the matching engines
-                // like stack overflows. We could fix the matching engine,
-                // but instead, we should just make the program smarter.
-                // Thus, we do a custom job here and instead of chaining the
-                // splits together, we simply point them to the MATCH
-                // instruction directly.
-                let (mut splits, mut starts) = (vec![], vec![]);
-                for _ in min..max {
-                    splits.push(self.empty_split());
-                    starts.push(self.insts.len());
-                    try!(self.c(e.clone()));
-                }
-                let end = self.insts.len();
-                for (split, start) in splits.into_iter().zip(starts) {
-                    if greedy {
-                        self.set_split(split, start, end);
-                    } else {
-                        self.set_split(split, end, start);
-                    }
+        }
+    }
+
+    fn c_repeat_zero_or_one(
+        &mut self,
+        expr: &Expr,
+        greedy: bool,
+    ) -> CompileResult {
+        let split = self.push_split_hole();
+        let goto1 = self.insts.len();
+        let hole = try!(self.c(expr));
+        let goto2 = self.insts.len();
+
+        if greedy {
+            self.fill_split(split, Some(goto1), Some(goto2));
+        } else {
+            self.fill_split(split, Some(goto2), Some(goto1));
+        }
+        Ok(hole)
+    }
+
+    fn c_repeat_zero_or_more(
+        &mut self,
+        expr: &Expr,
+        greedy: bool,
+    ) -> CompileResult {
+        let goto_split = self.insts.len();
+        let split = self.push_split_hole();
+        let goto_rep_expr = self.insts.len();
+        let hole_rep_expr = try!(self.c(expr));
+
+        self.fill(hole_rep_expr, goto_split);
+        Ok(if greedy {
+            self.fill_split(split, Some(goto_rep_expr), None)
+        } else {
+            self.fill_split(split, None, Some(goto_rep_expr))
+        })
+    }
+
+    fn c_repeat_one_or_more(
+        &mut self,
+        expr: &Expr,
+        greedy: bool,
+    ) -> CompileResult {
+        let goto_rep_expr = self.insts.len();
+        let hole_rep_expr = try!(self.c(expr));
+        self.fill_to_next(hole_rep_expr);
+        let split = self.push_split_hole();
+
+        Ok(if greedy {
+            self.fill_split(split, Some(goto_rep_expr), None)
+        } else {
+            self.fill_split(split, None, Some(goto_rep_expr))
+        })
+    }
+
+    fn c_repeat_range_min_or_more(
+        &mut self,
+        expr: &Expr,
+        greedy: bool,
+        min: u32,
+    ) -> CompileResult {
+        let min = u32_to_usize(min);
+        if min == 0 {
+            return self.c_repeat_zero_or_more(expr, greedy);
+        }
+        let hole = try!(self.c_concat(iter::repeat(expr).take(min - 1)));
+        self.fill_to_next(hole);
+        self.c_repeat_one_or_more(expr, greedy)
+    }
+
+    fn c_repeat_range(
+        &mut self,
+        expr: &Expr,
+        greedy: bool,
+        min: u32,
+        max: u32,
+    ) -> CompileResult {
+        let (min, max) = (u32_to_usize(min), u32_to_usize(max));
+        let hole = try!(self.c_concat(iter::repeat(expr).take(min)));
+        if min == max {
+            return Ok(hole);
+        }
+        self.fill_to_next(hole);
+        // It is much simpler to compile, e.g., `a{2,5}` as:
+        //
+        //     aaa?a?a?
+        //
+        // But you end up with a sequence of instructions like this:
+        //
+        //     0: 'a'
+        //     1: 'a',
+        //     2: split(3, 4)
+        //     3: 'a'
+        //     4: split(5, 6)
+        //     5: 'a'
+        //     6: split(7, 8)
+        //     7: 'a'
+        //     8: MATCH
+        //
+        // This is *incredibly* inefficient because the splits end
+        // up forming a chain. Given a much larger number than `5`,
+        // it is easy cause perverse behavior in the matching engines
+        // like stack overflows. We could fix the matching engine,
+        // but instead, we should just make the program smarter.
+        // Thus, we do a custom job here and instead of chaining the
+        // splits together, we simply point them to the MATCH
+        // instruction directly (for example).
+        let mut holes = vec![];
+        let mut prev_hole = Hole::None;
+        for _ in min..max {
+            self.fill_to_next(prev_hole);
+            let split = self.push_split_hole();
+            let goto_rep_expr = self.insts.len();
+            prev_hole = try!(self.c(expr));
+            if greedy {
+                holes.push(self.fill_split(split, Some(goto_rep_expr), None));
+            } else {
+                holes.push(self.fill_split(split, None, Some(goto_rep_expr)));
+            }
+        }
+        holes.push(prev_hole);
+        Ok(Hole::Many(holes))
+    }
+
+    fn fill(&mut self, hole: Hole, goto: InstIdx) {
+        match hole {
+            Hole::None => {}
+            Hole::One(pc) => {
+                self.insts[pc].complete(goto);
+            }
+            Hole::Many(holes) => {
+                for hole in holes {
+                    self.fill(hole, goto);
                 }
             }
         }
-        self.check_size()
+    }
+
+    fn fill_to_next(&mut self, hole: Hole) {
+        let next = self.insts.len();
+        self.fill(hole, next);
+    }
+
+    fn fill_split(
+        &mut self,
+        hole: Hole,
+        goto1: Option<InstIdx>,
+        goto2: Option<InstIdx>,
+    ) -> Hole {
+        match hole {
+            Hole::None => Hole::None,
+            Hole::One(pc) => {
+                match (goto1, goto2) {
+                    (Some(goto1), Some(goto2)) => {
+                        self.insts[pc].complete_split(goto1, goto2);
+                        Hole::None
+                    }
+                    (Some(goto1), None) => {
+                        self.insts[pc].complete_split_goto1(goto1);
+                        Hole::One(pc)
+                    }
+                    (None, Some(goto2)) => {
+                        self.insts[pc].complete_split_goto2(goto2);
+                        Hole::One(pc)
+                    }
+                    (None, None) => unreachable!("at least one of the split \
+                                                  holes must be filled"),
+                }
+            }
+            Hole::Many(holes) => {
+                let mut new_holes = vec![];
+                for hole in holes {
+                    new_holes.push(self.fill_split(hole, goto1, goto2));
+                }
+                if new_holes.is_empty() {
+                    Hole::None
+                } else if new_holes.len() == 1 {
+                    new_holes.pop().unwrap()
+                } else {
+                    Hole::Many(new_holes)
+                }
+            }
+        }
+    }
+
+    fn push_compiled(&mut self, inst: Inst) {
+        self.insts.push(MaybeInst::Compiled(inst));
+    }
+
+    fn push_hole(&mut self, inst: MaybeInst) -> Hole {
+        let hole = self.insts.len();
+        self.insts.push(inst);
+        Hole::One(hole)
+    }
+
+    fn push_split_hole(&mut self) -> Hole {
+        let hole = self.insts.len();
+        self.insts.push(MaybeInst::Split);
+        Hole::One(hole)
     }
 
     fn check_size(&self) -> Result<(), Error> {
@@ -236,52 +388,131 @@ impl Compiler {
             Ok(())
         }
     }
+}
 
-    /// Appends the given instruction to the program.
-    #[inline]
-    fn push(&mut self, x: Inst) {
-        self.insts.push(x)
+/// Hole represents a pointer to zero or more instructions in a regex program
+/// that need to have their goto fields set to the same location.
+#[derive(Debug)]
+enum Hole {
+    None,
+    One(InstIdx),
+    Many(Vec<Hole>),
+}
+
+/// MaybeInst represents a possibly incomplete instruction in a regex program.
+/// The nature of incompleteness is always determined by whether the
+/// instruction's "goto" field has been set or not.
+///
+/// In the case of Split, since it has two goto fields, it can be "incomplete"
+/// in three different ways: either none of its fields are set, only the first
+/// is set or only the second is set. The reason why the first and second
+/// fields are distinguished is because the order of the branch matters. (i.e.,
+/// it's how "greedy" and "ungreedy" semantics are implemented.)
+///
+/// When the compiler is finished, *all* of its possibly incomplete
+/// instructions must have been fully compiled where all goto fields in all
+/// instructions are set. Violation of this invariant is a bug.
+#[derive(Clone, Debug)]
+enum MaybeInst {
+    /// Compiled represents an instruction that is fully compiled. That is,
+    /// all of its "goto" fields have been filled. When the compiler is done,
+    /// all MaybeInsts must be of the Compiled form.
+    Compiled(Inst),
+    /// Split is a branch instruction where neither of its goto fields have
+    /// been set.
+    Split,
+    /// Split1 is a branch instruction where only the first goto field has
+    /// been set.
+    Split1(InstIdx),
+    /// Split2 is a branch instruction where only the second goto field has
+    /// been set.
+    Split2(InstIdx),
+    /// Save is a capture instruction whose goto field has not been set.
+    Save { slot: usize },
+    /// EmptyLook is a zero-width assertion instruction whose goto field has
+    /// not been set.
+    EmptyLook { look: EmptyLook },
+    /// Char is a character-match instruction whose goto field has not been
+    /// set.
+    Char { c: char },
+    /// Ranges is a character-range-match instruction whose goto field has not
+    /// been set.
+    Ranges { ranges: Vec<(char, char)> },
+}
+
+impl MaybeInst {
+    fn complete(&mut self, goto: InstIdx) {
+        let filled = match *self {
+            MaybeInst::Save { slot } => Inst::Save(InstSave {
+                goto: goto,
+                slot: slot,
+            }),
+            MaybeInst::EmptyLook { look } => Inst::EmptyLook(InstEmptyLook {
+                goto: goto,
+                look: look,
+            }),
+            MaybeInst::Char { c } => Inst::Char(InstChar {
+                goto: goto,
+                c: c,
+            }),
+            MaybeInst::Ranges { ref ranges } => Inst::Ranges(InstRanges {
+                goto: goto,
+                ranges: ranges.clone(),
+            }),
+            MaybeInst::Split1(goto1) => {
+                Inst::Split(InstSplit { goto1: goto1, goto2: goto })
+            }
+            MaybeInst::Split2(goto2) => {
+                Inst::Split(InstSplit { goto1: goto, goto2: goto2 })
+            }
+            _ => unreachable!("must be called on an uncompiled instruction \
+                               with exactly one missing goto field, \
+                               instead it was called on: {:?}", self),
+        };
+        *self = MaybeInst::Compiled(filled);
     }
 
-    /// Appends an *empty* `Split` instruction to the program and returns
-    /// the index of that instruction. (The index can then be used to "patch"
-    /// the actual locations of the split in later.)
-    #[inline]
-    fn empty_split(&mut self) -> InstIdx {
-        self.insts.push(Inst::Split(0, 0));
-        self.insts.len() - 1
+    fn complete_split(&mut self, goto1: InstIdx, goto2: InstIdx) {
+        let filled = match *self {
+            MaybeInst::Split => {
+                Inst::Split(InstSplit { goto1: goto1, goto2: goto2 })
+            }
+            _ => unreachable!("must be called on Split instruction, \
+                               instead it was called on: {:?}", self),
+        };
+        *self = MaybeInst::Compiled(filled);
     }
 
-    /// Sets the left and right locations of a `Split` instruction at index
-    /// `i` to `pc1` and `pc2`, respectively.
-    /// If the instruction at index `i` isn't a `Split` instruction, then
-    /// `panic!` is called.
-    #[inline]
-    fn set_split(&mut self, i: InstIdx, pc1: InstIdx, pc2: InstIdx) {
-        let split = &mut self.insts[i];
-        match *split {
-            Inst::Split(_, _) => *split = Inst::Split(pc1, pc2),
-            _ => panic!("BUG: Invalid split index."),
+    fn complete_split_goto1(&mut self, goto1: InstIdx) {
+        let half_filled = match *self {
+            MaybeInst::Split => goto1,
+            _ => unreachable!("must be called on Split instruction, \
+                               instead it was called on: {:?}", self),
+        };
+        *self = MaybeInst::Split1(half_filled);
+    }
+
+    fn complete_split_goto2(&mut self, goto2: InstIdx) {
+        let half_filled = match *self {
+            MaybeInst::Split => goto2,
+            _ => unreachable!("must be called on Split instruction, \
+                               instead it was called on: {:?}", self),
+        };
+        *self = MaybeInst::Split2(half_filled);
+    }
+
+    fn unwrap(self) -> Inst {
+        match self {
+            MaybeInst::Compiled(inst) => inst,
+            _ => unreachable!("must be called on a compiled instruction, \
+                               instead it was called on: {:?}", self),
         }
     }
+}
 
-    /// Appends an *empty* `Jump` instruction to the program and returns the
-    /// index of that instruction.
-    #[inline]
-    fn empty_jump(&mut self) -> InstIdx {
-        self.insts.push(Inst::Jump(0));
-        self.insts.len() - 1
+fn u32_to_usize(n: u32) -> usize {
+    if (n as u64) > (::std::usize::MAX as u64) {
+        panic!("BUG: {} is too big to be pointer sized", n)
     }
-
-    /// Sets the location of a `Jump` instruction at index `i` to `pc`.
-    /// If the instruction at index `i` isn't a `Jump` instruction, then
-    /// `panic!` is called.
-    #[inline]
-    fn set_jump(&mut self, i: InstIdx, pc: InstIdx) {
-        let jmp = &mut self.insts[i];
-        match *jmp {
-            Inst::Jump(_) => *jmp = Inst::Jump(pc),
-            _ => panic!("BUG: Invalid jump index."),
-        }
-    }
+    n as usize
 }

--- a/src/inst.rs
+++ b/src/inst.rs
@@ -1,0 +1,142 @@
+use std::cmp::Ordering;
+
+use char::Char;
+
+/// InstIdx represents the index of an instruction in a regex program.
+pub type InstIdx = usize;
+
+/// Inst is an instruction code in a Regex program.
+#[derive(Clone, Debug)]
+pub enum Inst {
+    /// Match indicates that the program has reached a match state.
+    Match,
+    /// Save causes the program to save the current location of the input in
+    /// the slot indicated by InstSave.
+    Save(InstSave),
+    /// Split causes the program to diverge to one of two paths in the
+    /// program, preferring goto1 in InstSplit.
+    Split(InstSplit),
+    /// EmptyLook represents a zero-width assertion in a regex program. A
+    /// zero-width assertion does not consume any of the input text.
+    EmptyLook(InstEmptyLook),
+    /// Char requires the regex program to match the character in InstChar at
+    /// the current position in the input.
+    Char(InstChar),
+    /// Ranges requires the regex program to match the character at the current
+    /// position in the input with one of the ranges specified in InstRanges.
+    Ranges(InstRanges),
+}
+
+/// Representation of the Save instruction.
+#[derive(Clone, Debug)]
+pub struct InstSave {
+    /// The next location to execute in the program.
+    pub goto: InstIdx,
+    /// The capture slot (there are two slots for every capture in a regex,
+    /// including the zeroth capture for the entire match).
+    pub slot: usize,
+}
+
+/// Representation of the Split instruction.
+#[derive(Clone, Debug)]
+pub struct InstSplit {
+    /// The first instruction to try. A match resulting from following goto1
+    /// has precedence over a match resulting from following goto2.
+    pub goto1: InstIdx,
+    /// The second instruction to try. A match resulting from following goto1
+    /// has precedence over a match resulting from following goto2.
+    pub goto2: InstIdx,
+}
+
+/// Representation of the EmptyLook instruction.
+#[derive(Clone, Debug)]
+pub struct InstEmptyLook {
+    /// The next location to execute in the program if this instruction
+    /// succeeds.
+    pub goto: InstIdx,
+    /// The type of zero-width assertion to check.
+    pub look: EmptyLook,
+}
+
+/// The set of zero-width match instructions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EmptyLook {
+    /// Start of line or input.
+    StartLine,
+    /// End of line or input.
+    EndLine,
+    /// Start of input.
+    StartText,
+    /// End of input.
+    EndText,
+    /// Word character on one side and non-word character on other.
+    WordBoundary,
+    /// Word character on both sides or non-word character on both sides.
+    NotWordBoundary,
+}
+
+impl InstEmptyLook {
+    /// Tests whether the pair of characters matches this zero-width
+    /// instruction.
+    pub fn matches(&self, c1: Char, c2: Char) -> bool {
+        use self::EmptyLook::*;
+        match self.look {
+            StartLine => c1.is_none() || c1 == '\n',
+            EndLine => c2.is_none() || c2 == '\n',
+            StartText => c1.is_none(),
+            EndText => c2.is_none(),
+            ref wbty => {
+                let (w1, w2) = (c1.is_word_char(), c2.is_word_char());
+                (*wbty == WordBoundary && w1 ^ w2)
+                || (*wbty == NotWordBoundary && !(w1 ^ w2))
+            }
+        }
+    }
+}
+
+/// Representation of the Char instruction.
+#[derive(Clone, Debug)]
+pub struct InstChar {
+    /// The next location to execute in the program if this instruction
+    /// succeeds.
+    pub goto: InstIdx,
+    /// The character to test.
+    pub c: char,
+}
+
+/// Representation of the Ranges instruction.
+#[derive(Clone, Debug)]
+pub struct InstRanges {
+    /// The next location to execute in the program if this instruction
+    /// succeeds.
+    pub goto: InstIdx,
+    /// The set of Unicode scalar value ranges to test.
+    pub ranges: Vec<(char, char)>,
+}
+
+impl InstRanges {
+    /// Tests whether the given input character matches this instruction.
+    #[inline(always)] // About ~5-15% more throughput then `#[inline]`
+    pub fn matches(&self, c: Char) -> bool {
+        // This speeds up the `match_class_unicode` benchmark by checking
+        // some common cases quickly without binary search. e.g., Matching
+        // a Unicode class on predominantly ASCII text.
+        for r in self.ranges.iter().take(4) {
+            if c < r.0 {
+                return false;
+            }
+            if c <= r.1 {
+                return true;
+            }
+        }
+        self.ranges.binary_search_by(|r| {
+            if r.1 < c {
+                Ordering::Less
+            } else if r.0 > c {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        }).is_ok()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,7 @@ mod backtrack;
 mod char;
 mod compile;
 mod input;
+mod inst;
 mod pool;
 mod prefix;
 mod program;
@@ -432,7 +433,8 @@ mod re;
 pub mod internal {
     pub use char::Char;
     pub use input::{Input, CharInput, InputAt};
-    pub use program::{Program, MatchEngine, CharRanges, Inst, LookInst};
+    pub use inst::{Inst, EmptyLook, InstRanges};
+    pub use program::{Program, MatchEngine};
     pub use re::ExNative;
     pub use re::Regex::{Dynamic, Native};
 }


### PR DESCRIPTION
The primary change here is the removal of the 'Jump' instruction.
Removing this instruction should in theory make execution slightly
faster overall, since there will be fewer instructions to execute.
The 'Jump' instruction is replaced by an explicit 'goto' field on
all of the other instructions (sans 'Match' and 'Split').

The impetus for this change is as a precursor to switching to a byte
based automaton. In particular, in order to efficiently compile
a UTF-8 automaton, we must factor out common suffixes in the byte-based
character classes, or else suffer dramatically increased program sizes.
Factoring out common suffixes does lead to a more complicated program
however, which would need to heavily rely on the 'Jump' instruction if
it existed, which doesn't seem optimal to me (and would negate some of
the size benefit of removing common suffixes).

In the process of rewriting the compiler, I've also attempted to make
the setting of the 'goto' fields a bit more clearer with an explicit
representation for "Holes." It doesn't encode as many invariants into the
type system as I'd like, but it should at least prevent errant hole-filling
at runtime (panic'ing on an invariant violation).