### PR TITLE
Rust upgrade to rustc 1.7.0-nightly (d70ab2bdf)

### DIFF
--- a/regex_macros/src/lib.rs
+++ b/regex_macros/src/lib.rs
@@ -552,7 +552,7 @@ fn parse(cx: &mut ExtCtxt, tts: &[ast::TokenTree]) -> Option<String> {
                 return None
             }
         };
-        if !parser.eat(&token::Eof).ok().unwrap() {
+        if !parser.eat(&token::Eof) {
             cx.span_err(parser.span, "only one string literal allowed");
             return None;
         }


### PR DESCRIPTION
multirust now has *rustc 1.7.0-nightly (d70ab2bdf 2016-01-08)*.
Fix #147.