### PR TITLE
Remove last_match fields from FindCaptures and FindMatches

### DIFF
--- a/regex_macros/tests/tests.rs
+++ b/regex_macros/tests/tests.rs
@@ -46,6 +46,27 @@ fn empty_regex_nonempty_match() {
 }
 
 #[test]
+fn one_zero_length_match() {
+    let re = regex!(r"\d*");
+    let ms = re.find_iter("a1b2").collect::<Vec<_>>();
+    assert_eq!(ms, vec![(0, 0), (1, 2), (3, 4)]);
+}
+
+#[test]
+fn many_zero_length_match() {
+    let re = regex!(r"\d*");
+    let ms = re.find_iter("a1bbb2").collect::<Vec<_>>();
+    assert_eq!(ms, vec![(0, 0), (1, 2), (3, 3), (4, 4), (5, 6)]);
+}
+
+#[test]
+fn many_sequential_zero_length_match() {
+    let re = regex!(r"\d?");
+    let ms = re.find_iter("a12b3c").collect::<Vec<_>>();
+    assert_eq!(ms, vec![(0, 0), (1, 2), (2, 3), (4, 5), (6, 6)]);
+}
+
+#[test]
 fn quoted_bracket_set() {
     let re = regex!(r"([\x{5b}\x{5d}])");
     let ms = re.find_iter("[]").collect::<Vec<_>>();

--- a/src/re.rs
+++ b/src/re.rs
@@ -1078,7 +1078,7 @@ impl<'r, 't> Iterator for FindCaptures<'r, 't> {
         // i.e., no infinite loops please.
         if e == s {
             self.last_end += self.search[self.last_end..].chars()
-                                 .next().map(|c| c.len_utf8()).unwrap_or(0);
+                                 .next().map(|c| c.len_utf8()).unwrap_or(1);
         } else {
             self.last_end = e;
         }

--- a/src/re.rs
+++ b/src/re.rs
@@ -350,6 +350,7 @@ impl Regex {
             re: self,
             search: text,
             last_end: 0,
+            skip_next_empty: false
         }
     }
 
@@ -454,6 +455,7 @@ impl Regex {
             re: self,
             search: text,
             last_end: 0,
+            skip_next_empty: false
         }
     }
 
@@ -1058,6 +1060,7 @@ pub struct FindCaptures<'r, 't> {
     re: &'r Regex,
     search: &'t str,
     last_end: usize,
+    skip_next_empty: bool
 }
 
 impl<'r, 't> Iterator for FindCaptures<'r, 't> {
@@ -1079,8 +1082,13 @@ impl<'r, 't> Iterator for FindCaptures<'r, 't> {
         if e == s {
             self.last_end += self.search[self.last_end..].chars()
                                  .next().map(|c| c.len_utf8()).unwrap_or(1);
+            if self.skip_next_empty {
+                self.skip_next_empty = false;
+                return self.next();
+            }
         } else {
             self.last_end = e;
+            self.skip_next_empty = true;
         }
         Some(Captures::new(self.re, self.search, caps))
     }
@@ -1098,6 +1106,7 @@ pub struct FindMatches<'r, 't> {
     re: &'r Regex,
     search: &'t str,
     last_end: usize,
+    skip_next_empty: bool
 }
 
 impl<'r, 't> Iterator for FindMatches<'r, 't> {
@@ -1119,8 +1128,13 @@ impl<'r, 't> Iterator for FindMatches<'r, 't> {
         if e == s {
             self.last_end += self.search[self.last_end..].chars()
                                  .next().map(|c| c.len_utf8()).unwrap_or(1);
+            if self.skip_next_empty {
+                self.skip_next_empty = false;
+                return self.next();
+            }
         } else {
             self.last_end = e;
+            self.skip_next_empty = true;
         }
         Some((s, e))
     }

--- a/src/re.rs
+++ b/src/re.rs
@@ -350,7 +350,6 @@ impl Regex {
             re: self,
             search: text,
             last_end: 0,
-            last_match: None,
         }
     }
 
@@ -454,7 +453,6 @@ impl Regex {
         FindCaptures {
             re: self,
             search: text,
-            last_match: None,
             last_end: 0,
         }
     }
@@ -1059,7 +1057,6 @@ impl<'t> Iterator for SubCapturesNamed<'t> {
 pub struct FindCaptures<'r, 't> {
     re: &'r Regex,
     search: &'t str,
-    last_match: Option<usize>,
     last_end: usize,
 }
 
@@ -1079,16 +1076,12 @@ impl<'r, 't> Iterator for FindCaptures<'r, 't> {
 
         // Don't accept empty matches immediately following a match.
         // i.e., no infinite loops please.
-        if e == s && Some(self.last_end) == self.last_match {
-            if self.last_end >= self.search.len() {
-                return None;
-            }
+        if e == s {
             self.last_end += self.search[self.last_end..].chars()
-                                 .next().unwrap().len_utf8();
-            return self.next()
+                                 .next().map(|c| c.len_utf8()).unwrap_or(0);
+        } else {
+            self.last_end = e;
         }
-        self.last_end = e;
-        self.last_match = Some(self.last_end);
         Some(Captures::new(self.re, self.search, caps))
     }
 }
@@ -1104,7 +1097,6 @@ impl<'r, 't> Iterator for FindCaptures<'r, 't> {
 pub struct FindMatches<'r, 't> {
     re: &'r Regex,
     search: &'t str,
-    last_match: Option<usize>,
     last_end: usize,
 }
 
@@ -1124,16 +1116,12 @@ impl<'r, 't> Iterator for FindMatches<'r, 't> {
 
         // Don't accept empty matches immediately following a match.
         // i.e., no infinite loops please.
-        if e == s && Some(self.last_end) == self.last_match {
-            if self.last_end >= self.search.len() {
-                return None;
-            }
+        if e == s {
             self.last_end += self.search[self.last_end..].chars()
-                                 .next().unwrap().len_utf8();
-            return self.next()
+                                 .next().map(|c| c.len_utf8()).unwrap_or(1);
+        } else {
+            self.last_end = e;
         }
-        self.last_end = e;
-        self.last_match = Some(self.last_end);
         Some((s, e))
     }
 }


### PR DESCRIPTION
I removed `last_match` fields from `FindCaptures` and `FindMatches` structs and simplified algorithm of `next` method.

I think that behavior of iterators should not change (at least, all tests are passed), but please double-check that.