### PR TITLE
Set `bench = false` for the main library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ rand = "0.3"
 # Enable to use the unstable pattern traits defined in std.
 pattern = []
 
+[lib]
+# There are no benchmarks in the library code itself
+bench = false
+
 # Runs unit tests defined inside the regex package.
 # Generally these tests specific pieces of the regex implementation.
 [[test]]


### PR DESCRIPTION
Set `bench = false` for the main library

Without this setting, the regex crate is compiled twice for cargo bench
-- once as a library, once with --test for benchmarking. Since there are
no benchmarks in the library itself it's faster to just skip this
compile.

I found this out recently, so this PR is a way to tell you about this little gotcha.
Saving time is always nice.