### PR TITLE
Add ASCII word boundaries to the lazy DFA.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -11,33 +11,32 @@ expressions using finite automata: https://swtch.com/~rsc/regexp/
 ## Architecture overview
 
 As you probably already know, this library executes regular expressions using
-finite automata. In particular, a design goal is to make searching linear with
-respect to both the regular expression and the text being searched. Meeting
-that design goal on its own is not so hard and can be done with an
-implementation of the NFA algorithm, as described in:
-https://swtch.com/~rsc/regexp/regexp2.html --- This library contains such an
-implementation in src/nfa.rs. (N.B. PCRE's documentation also claims to
-implement the NFA algorithm by citing Jeffrey Friedl's book, "Mastering Regular
-Expressions." The book unfortunately conflates terminology.)
+finite automata. In particular, a design goal is to make searching linear
+with respect to both the regular expression and the text being searched.
+Meeting that design goal on its own is not so hard and can be done with an
+implementation of the Pike VM (similar to Thompson's construction, but supports
+capturing groups), as described in: https://swtch.com/~rsc/regexp/regexp2.html
+--- This library contains such an implementation in src/pikevm.rs.
 
-Making it fast is harder. One of the key problems with the NFA algorithm is
-that it can be in more than one state at any point in time, and must shuffle
-sub-capture positions between them. The NFA algorithm also spends a lot of
-time following the same epsilon transitions over and over again. We can employ
-one trick to speed up the NFA algorithm: extract one or more literal prefixes
-from the regular expression and execute specialized code to quickly find
-matches of those prefixes in the search text. The NFA algorithm can then be
-avoided for most the search, and instead only executed when a prefix is found.
-The code to find prefixes and search for prefixes is in src/literals.rs. When
-more than one literal prefix is found, we fall back to an Aho-Corasick DFA
-using the aho-corasick crate. For one literal, we use a variant of the
-Boyer-Moore algorithm. Both Aho-Corasick and Boyer-Moore use `memchr` when
-appropriate. The Boyer-Moore variant in this library also uses elementary
-frequency analysis to choose the write byte to run `memchr` with.
+Making it fast is harder. One of the key problems with the Pike VM is that it
+can be in more than one state at any point in time, and must shuffle capture
+positions between them. The Pike VM also spends a lot of time following the
+same epsilon transitions over and over again. We can employ one trick to
+speed up the Pike VM: extract one or more literal prefixes from the regular
+expression and execute specialized code to quickly find matches of those
+prefixes in the search text. The Pike VM can then be avoided for most the
+search, and instead only executed when a prefix is found. The code to find
+prefixes is in the regex-syntax crate (in this repository). The code to search
+for literals is in src/literals.rs. When more than one literal prefix is found,
+we fall back to an Aho-Corasick DFA using the aho-corasick crate. For one
+literal, we use a variant of the Boyer-Moore algorithm. Both Aho-Corasick and
+Boyer-Moore use `memchr` when appropriate. The Boyer-Moore variant in this
+library also uses elementary frequency analysis to choose the right byte to run
+`memchr` with.
 
 Of course, detecting prefix literals can only take us so far. Not all regular
-expressions have literal prefixes. To remedy this, we try another approach to
-executing the NFA: backtracking, whose implementation can be found in
+expressions have literal prefixes. To remedy this, we try another approach
+to executing the Pike VM: backtracking, whose implementation can be found in
 src/backtrack.rs. One reason why backtracking can be faster is that it avoids
 excessive shuffling of capture groups. Of course, backtracking is susceptible
 to exponential runtimes, so we keep track of every state we've visited to make
@@ -47,16 +46,16 @@ memory requirement, we only use this engine on small search strings *and* small
 regular expressions.
 
 Lastly, the real workhorse of this library is the "lazy" DFA in src/dfa.rs.
-It is distinct from the NFA algorithm in that the DFA is explicitly represented
-in memory and is only ever in one state at a time. It is said to be "lazy"
-because the DFA is computed as text is searched, where each byte in the search
-text results in at most one new DFA state. It is made fast by caching states.
-DFAs are susceptible to exponential state blow up (where the worst case is
-computing a new state for every input byte, regardless of what's in the state
-cache). To avoid using a lot of memory, the lazy DFA uses a bounded cache. Once
-the cache is full, it is wiped and state computation starts over again. If the
-cache is wiped too frequently, then the DFA gives up and searching falls back
-to one of the aforementioned algorithms.
+It is distinct from the Pike VM in that the DFA is explicitly represented in
+memory and is only ever in one state at a time. It is said to be "lazy" because
+the DFA is computed as text is searched, where each byte in the search text
+results in at most one new DFA state. It is made fast by caching states. DFAs
+are susceptible to exponential state blow up (where the worst case is computing
+a new state for every input byte, regardless of what's in the state cache). To
+avoid using a lot of memory, the lazy DFA uses a bounded cache. Once the cache
+is full, it is wiped and state computation starts over again. If the cache is
+wiped too frequently, then the DFA gives up and searching falls back to one of
+the aforementioned algorithms.
 
 All of the above matching engines expose precisely the same matching semantics.
 This is indeed tested. (See the section below about testing.)
@@ -101,7 +100,7 @@ should be stored in a captured location. Split instructions represent a binary
 branch in the program (i.e., epsilon transitions). The instructions `'a'` and
 `'b'` indicate that the literal bytes `'a'` or `'b'` should match.
 
-In older versions of this library, the compilation would looked like this:
+In older versions of this library, the compilation looked like this:
 
     000 Save(0)
     001 Split(2, 3)
@@ -114,26 +113,24 @@ In older versions of this library, the compilation would looked like this:
 In particular, empty instructions that merely served to move execution from one
 point in the program to another were removed. Instead, every instruction has a
 `goto` pointer embedded into it. This resulted in a small performance boost for
-the NFA algorithm, because it was one fewer epsilon transition that it had to
-follow.
+the Pike VM, because it was one fewer epsilon transition that it had to follow.
 
 There exist more instructions and they are defined and documented in
 src/prog.rs.
 
 Compilation has several knobs and a few unfortunately complicated invariants.
 Namely, the output of compilation can be one of two types of programs: a
-program that executes on Unicode scalar values or a program that executes on
-raw bytes. In the former case, the matching engine is responsible for
+program that executes on Unicode scalar values or a program that executes
+on raw bytes. In the former case, the matching engine is responsible for
 performing UTF-8 decoding and executing instructions using Unicode codepoints.
 In the latter case, the program handles UTF-8 decoding implicitly, so that the
 matching engine can execute on raw bytes. All matching engines can execute
 either Unicode or byte based programs except for the lazy DFA, which requires
 byte based programs. In general, both representations were kept because (1) the
 lazy DFA requires byte based programs so that states can be encoded in a memory
-efficient manner and (2) the NFA algorithm benefits greatly from inlining
-Unicode character classes into fewer instructions as it results in fewer
-epsilon transitions. This means that every compiled program contains a proper
-subset of all available instructions.
+efficient manner and (2) the Pike VM benefits greatly from inlining Unicode
+character classes into fewer instructions as it results in fewer epsilon
+transitions.
 
 N.B. UTF-8 decoding is built into the compiled program by making use of the
 utf8-ranges crate. The compiler in this library factors out common suffixes to
@@ -156,10 +153,10 @@ boundary assertions and (2) the caller never asks for sub-capture locations.
 
 At the time of writing, there are four matching engines in this library:
 
-1. The NFA algorithm (supports captures).
+1. The Pike VM (supports captures).
 2. Bounded backtracking (supports captures).
 3. Literal substring or multi-substring search.
-4. Lazy DFA (no support for word boundary assertions).
+4. Lazy DFA (no support for Unicode word boundary assertions).
 
 Only the first two matching engines are capable of executing every regular
 expression program. They also happen to be the slowest, which means we need
@@ -168,54 +165,40 @@ knows what the caller wants. Using this information, we can determine which
 engine (or engines) to use.
 
 The logic for choosing which engine to execute is in src/exec.rs and is
-documented on the Exec type. Exec values contain regular expression
-Programs (defined in src/prog.rs), which contain all the necessary tidbits
-for actually executing a regular expression on search text.
+documented on the Exec type. Exec values contain regular expression Programs
+(defined in src/prog.rs), which contain all the necessary tidbits for actually
+executing a regular expression on search text.
 
 For the most part, the execution logic is straight-forward and follows the
-limitations of each engine described above pretty faithfully. The hairiest part
-of src/exec.rs by far is the execution of the lazy DFA, since it requires a
-forwards and backwards search, and then falls back to either the NFA algorithm
-or backtracking if the caller requested capture locations.
+limitations of each engine described above pretty faithfully. The hairiest
+part of src/exec.rs by far is the execution of the lazy DFA, since it requires
+a forwards and backwards search, and then falls back to either the Pike VM or
+backtracking if the caller requested capture locations.
 
-The parameterization of every search is defined in src/params.rs. Among other
-things, search parameters provide storage for recording capture locations and
-matches (for regex sets). The existence and nature of storage is itself a
-configuration for how each matching engine behaves. For example, if no storage
-for capture locations is provided, then the matching engines can give up as
-soon as a match is witnessed (which may occur well before the leftmost-first
-match).
+The Exec type also contains mutable scratch space for each type of matching
+engine. This scratch space is used during search (for example, for the lazy
+DFA, it contains compiled states that are reused on subsequent searches).
 
 ### Programs
 
 A regular expression program is essentially a sequence of opcodes produced by
-the compiler plus various caches for the matching engines plus various facts
-about the regular expression (such as whether it is anchored, it capture names,
-etc.).
-
-The regular expression program contains mutable caches for use by the matching
-engines. For example, the NFA algorithm stores its "execution threads" there,
-the backtracking engine stores its visited map and the lazy DFA stores its
-state cache. In sum, they are beneficial to performance because it allows reuse
-of previously done work (especially for the lazy DFA). Mutation of these caches
-should not be observable by callers, so it is done using interior mutability.
-To make it possible to share regular expressions across threads, the cache is
-guarded by a mutex but is not held during matching.
+the compiler plus various facts about the regular expression (such as whether
+it is anchored, its capture names, etc.).
 
 ### The regex! macro (or why `regex::internal` exists)
 
-The `regex!` macro is defined in the `regex_macros` crate as a compiled plugin,
+The `regex!` macro is defined in the `regex_macros` crate as a compiler plugin,
 which is maintained in this repository. The `regex!` macro compiles a regular
 expression at compile time into specialized Rust code.
 
 The `regex!` macro was written when this library was first conceived and
 unfortunately hasn't changed much since then. In particular, it encodes the
-entire NFA algorithm into stack allocated space (no heap allocation is done).
-When `regex!` was first written, this provided a substantial speed boost over
+entire Pike VM into stack allocated space (no heap allocation is done). When
+`regex!` was first written, this provided a substantial speed boost over
 so-called "dynamic" regexes compiled at runtime, and in particular had much
-lower overhead per match. This was because the only matching engine at the time
-was the NFA algorithm. The addition of other matching engines has inverted the
-relationship; the `regex!` macro is almost never faster than the dynamic
+lower overhead per match. This was because the only matching engine at the
+time was the Pike VM. The addition of other matching engines has inverted
+the relationship; the `regex!` macro is almost never faster than the dynamic
 variant. (In fact, it is typically substantially slower.)
 
 In order to build the `regex!` macro this way, it must have access to some
@@ -244,57 +227,62 @@ located in src/testdata. The scripts/regex-match-tests.py takes the test suite
 in src/testdata and generates tests/matches.rs.
 
 There are also many other manually crafted tests and regression tests in
-tests/tests.rs.
+tests/tests.rs. Some of these tests were taken from RE2.
 
 The biggest source of complexity in the tests is related to answering this
-question: how can we reuse the tests to check all of our matching engines?
-One approach would have been to encode every test into some kind of format
-(like the AT&T test suite) and code generate tests for each matching engine.
-The approach we use in this library is to create a Cargo.toml entry point for
-each matching engine we want to test. The entry points are:
+question: how can we reuse the tests to check all of our matching engines? One
+approach would have been to encode every test into some kind of format (like
+the AT&T test suite) and code generate tests for each matching engine. The
+approach we use in this library is to create a Cargo.toml entry point for each
+matching engine we want to test. The entry points are:
 
-* `tests/test_native.rs` - tests the `regex!` macro
-* `tests/test_dynamic.rs` - tests `Regex::new`
-* `tests/test_dynamic_nfa.rs` - tests `Regex::new`, forced to use the NFA
+* `tests/test_plugin.rs` - tests the `regex!` macro
+* `tests/test_default.rs` - tests `Regex::new`
+* `tests/test_default_bytes.rs` - tests `bytes::Regex::new`
+* `tests/test_nfa.rs` - tests `Regex::new`, forced to use the NFA
   algorithm on every regex.
-* `tests/test_dynamic_nfa_bytes.rs` - tests `Regex::new`, forced to use the NFA
-  algorithm on every regex and use byte based programs.
-* `tests/test_dynamic_backtrack.rs` - tests `Regex::new`, forced to use
+* `tests/test_nfa_bytes.rs` - tests `Regex::new`, forced to use the NFA
+  algorithm on every regex and use *arbitrary* byte based programs.
+* `tests/test_nfa_utf8bytes.rs` - tests `Regex::new`, forced to use the NFA
+  algorithm on every regex and use *UTF-8* byte based programs.
+* `tests/test_backtrack.rs` - tests `Regex::new`, forced to use
   backtracking on every regex.
-* `tests/test_dynamic_backtrack_bytes.rs` - tests `Regex::new`, forced to use
-  backtracking on every regex and use byte based programs.
+* `tests/test_backtrack_bytes.rs` - tests `Regex::new`, forced to use
+  backtracking on every regex and use *arbitrary* byte based programs.
+* `tests/test_backtrack_utf8bytes.rs` - tests `Regex::new`, forced to use
+  backtracking on every regex and use *UTF-8* byte based programs.
 
-The lazy DFA and pure literal engines are absent from this list because they
-cannot be used on every regular expression. Instead, we rely on
+The lazy DFA and pure literal engines are absent from this list because
+they cannot be used on every regular expression. Instead, we rely on
 `tests/test_dynamic.rs` to test the lazy DFA and literal engines when possible.
 
 Since the tests are repeated several times, and because `cargo test` runs all
 entry points, it can take a while to compile everything. To reduce compile
-times slightly, try using `cargo test --test dynamic`, which will only use
-the `tests/test_dynamic.rs` entry point.
+times slightly, try using `cargo test --test default`, which will only use the
+`tests/test_default.rs` entry point.
 
 N.B. To run tests for the `regex!` macro, use:
 
-    cargo test --manifest-path regex_macros/Cargo.toml --test native
+    cargo test --manifest-path regex_macros/Cargo.toml
 
 
 ## Benchmarking
 
 The benchmarking in this crate is made up of many micro-benchmarks. Currently,
-there are two primary sets of benchmarks: the benchmarks that were adopted at
-this library's inception (in `benches/src/misc.rs`) and a newer set of benchmarks
-meant to test various optimizations. Specifically, the latter set contain some
-analysis and are in `benches/src/sherlock.rs`. Also, the latter set are all
-executed on the same lengthy input whereas the former benchmarks are executed
-on strings of varying length.
+there are two primary sets of benchmarks: the benchmarks that were adopted
+at this library's inception (in `benches/src/misc.rs`) and a newer set of
+benchmarks meant to test various optimizations. Specifically, the latter set
+contain some analysis and are in `benches/src/sherlock.rs`. Also, the latter
+set are all executed on the same lengthy input whereas the former benchmarks
+are executed on strings of varying length.
 
 There is also a smattering of benchmarks for parsing and compilation.
 
 Benchmarks are in a separate crate so that its dependencies can be managed
 separately from the main regex crate.
 
-Benchmarking follows a similarly wonky setup as tests. There are multiple
-entry points:
+Benchmarking follows a similarly wonky setup as tests. There are multiple entry
+points:
 
 * `bench_rust_plugin.rs` - benchmarks the `regex!` macro
 * `bench_rust.rs` - benchmarks `Regex::new`

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,274 @@
+Your friendly guide to understanding the performance characteristics of this
+crate.
+
+This guide assumes some familiarity with the public API of this crate, which
+can be found here: http://doc.rust-lang.org/regex/regex/index.html
+
+## Theory vs. Practice
+
+One of the design goals of this crate is to provide worst case linear time
+behavior with respect to the text searched using finite state automata. This
+means that, *in theory*, the performance of this crate is much better than most
+regex implementations, which typically use backtracking which has worst case
+exponential time.
+
+For example, try opening a Python interpreter and typing this:
+
+    >>> import re
+    >>> re.search('(a*)*c', 'a' * 30).span()
+
+I'll wait.
+
+At some point, you'll figure out that it won't terminate any time soon. ^C it.
+
+The promise of this crate is that *this pathological behavior can't happen*.
+
+With that said, just because we have protected ourselves against worst case
+exponential behavior up doesn't mean we are immune from large constant factors
+or places where the current regex engine isn't quite optimal. This guide will
+detail those cases, among other general advice, and give advice on how to avoid
+them.
+
+## Thou Shalt Not Compile Regular Expressions In A Loop
+
+Don't do it unless you really don't mind paying for it. Compiling a regular
+expression in this crate is quite expensive. It is conceivable that it may get
+faster some day, but I wouldn't hold out hope for, say, an order of magnitude
+improvement. In particular, compilation can take any where from a few dozen
+microseconds to a few dozen milliseconds. Yes, milliseconds. Unicode character
+classes, in particular, have the largest impact on compilation performance. At
+the time of writing, for example, `\pL{100}` takes around 44ms to compile. This
+is because `\pL` corresponds to every letter in Unicode and compilation must
+turn it into a proper automaton that decodes a subset of UTF-8 which
+corresponds to those letters. Compilation also spends some cycles shrinking the
+size of the automaton.
+
+This means that in order to realize efficient regex matching, one must
+*amortize the cost of compilation*. Trivially, if a call to `is_match` is
+inside a loop, then make sure your call to `Regex::new` is *outside* that loop.
+
+In many programming languages, regular expressions can be conveniently defined
+and "compiled" in a global scope, and code can reach out and use them as if
+they were global static variables. In Rust, there is really no concept of
+life-before-main, and therefore, one cannot utter this:
+
+    static MY_REGEX: Regex = Regex::new("...").unwrap();
+
+Unfortunately, this would seem to imply that one must pass `Regex` objects
+around to everywhere they are used, which can be especially painful depending
+on how your program is structured. Thankfully, the
+[`lazy_static`](https://crates.io/crates/lazy_static)
+crate provides an answer that works well:
+
+    #[macro_use] extern crate lazy_static;
+    extern crate regex;
+
+    use regex::Regex;
+
+    fn some_helper_function(text: &str) -> bool {
+        lazy_static! {
+            static ref MY_REGEX: Regex = Regex::new("...").unwrap();
+        }
+        MY_REGEX.is_match(text)
+    }
+
+In other words, the `lazy_static!` macro enables us to define a `Regex` *as if*
+it were a global static value. What is actually happening under the covers is
+that the code inside the macro (i.e., `Regex::new(...)`) is run on *first use*
+of `MY_REGEX` via a `Deref` impl. The implementation is admittedly magical, but
+it's self contained and everything works exactly as you expect. In particular,
+`MY_REGEX` can be used from multiple threads without wrapping it in an `Arc` or
+a `Mutex`. On that note...
+
+**Advice**: Use `lazy_static` to amortize the cost of `Regex` compilation.
+
+## Using a regex from multiple threads
+
+It is supported and encouraged to define your regexes using `lazy_static!` as
+if they were global static values, and then use them to search text from
+multiple threads simultaneously.
+
+One might imagine that this is possible because a `Regex` represents a
+*compiled* program, so that any allocation or mutation is already done, and is
+therefore read-only. Unfortunately, this is not true. Each type of search
+strategy in this crate requires some kind of mutable scratch space to use
+*during search*. For example, when executing a DFA, its states are computed
+lazily and reused on subsequent searches. Those states go into that mutable
+scratch space.
+
+The mutable scratch space is an implementation detail, and in general, its
+mutation should not be observable from users of this crate. Therefore, it uses
+interior mutability. This implies that `Regex` can either only be used from one
+thread, or it must do some sort of synchronization. Either choice is
+reasonable, but this crate chooses the latter, in particular because it is
+ergonomic and makes use with `lazy_static!` straight forward.
+
+Synchronization implies *some* amount of overhead. When a `Regex` is used from
+a single thread, this overhead is negligible. When a `Regex` is used from
+multiple threads simultaneously, it is possible for the overhead of
+synchronization from contention to impact performance. The specific cases where
+contention may happen is if you are calling any of these methods repeatedly
+from multiple threads simultaneously:
+
+* shortest_match
+* is_match
+* find
+* captures
+
+In particular, every invocation of one of these methods must synchronize with
+other threads to retrieve its mutable scratch space before searching can start.
+If, however, you are using one of these methods:
+
+* find_iter
+* captures_iter
+
+Then you may not suffer from contention since the cost of synchronization is
+amortized on *construction of the iterator*. That is, the mutable scratch space
+is obtained when the iterator is created and retained throughout its lifetime.
+
+**Advice**: The performance impact from using a `Regex` from multiple threads
+is likely negligible. If necessary, clone the `Regex` so that each thread gets
+its own copy. Cloning a regex does not incur any additional memory overhead
+than what would be used by using a `Regex` from multiple threads
+simultaneously. *Its only cost is ergonomics.*
+
+## Only ask for what you need
+
+There are three primary search methods on a `Regex`:
+
+* is_match
+* find
+* captures
+
+In general, these are ordered from fastest to slowest.
+
+`is_match` is fastest because it doesn't actually need to find the start or the
+end of the leftmost-first match. It can quit immediately after it knows there
+is a match. For example, given the regex `a+` and the haystack, `aaaaa`, the
+search will quit after examing the first byte.
+
+In constrast, `find` must return both the start and end location of the
+leftmost-first match. It can use the DFA matcher for this, but must run it
+forwards once to find the end of the match *and then run it backwards* to find
+the start of the match. The two scans and the cost of finding the real end of
+the leftmost-first match make this more expensive than `is_match`.
+
+`captures` is the most expensive of them all because it must do what `find`
+does, and then run either the bounded backtracker or the Pike VM to fill in the
+capture group locations. Both of these are simulations of an NFA, which must
+spend a lot of time shuffling states around. The DFA limits the performance hit
+somewhat by restricting the amount of text that must be searched via an NFA
+simulation.
+
+One other method not mentioned is `shortest_match`. This method has precisely
+the same performance characteristics as `is_match`, except it will return the
+end location of when it discovered a match. For example, given the regex `a+`
+and the haystack `aaaaa`, `shortest_match` may return `1` as opposed to `5`,
+the latter of which being the correct end location of the leftmost-first match.
+
+**Advice**: Prefer in this order: `is_match`, `find`, `captures`.
+
+## Literals in your regex may make it faster
+
+In particular, if your regex starts with a prefix literal, the prefix is
+quickly searched before entering the (much slower) regex engine. For example,
+given the regex `foo\w+`, the literal `foo` will be searched for using
+Boyer-Moore. If there's no match, then no regex engine is ever used. Only when
+there's a match is the regex engine invoked at the location of the match, which
+effectively permits the regex engine to skip large portions of a haystack.
+If a regex is comprised entirely of literals (possibly more than one), then
+it's possible that the regex engine can be avoided entirely even when there's a
+match.
+
+When one literal is found, Boyer-Moore is used. When multiple literals are
+found, then an optimized version of Aho-Coraisck is used.
+
+This optimization is in particular extended quite a bit in this crate. Here are
+a few examples of regexes that get literal prefixes detected:
+
+* `(foo|bar)` detects `foo` and `bar`
+* `(a|b)c` detects `ac` and `bc`
+* `[ab]foo[yz]` detects `afooy`, `afooz`, `bfooy` and `bfooz`
+* `a?b` detects `a` and `b`
+* `a*b` detects `a` and `b`
+* `(ab){3,6}` detects `ababab`
+
+Literals may also be used in other ways. For example, if a regex *ends* with a
+literal, then it may be possible to scan for that literal and search backwards
+from a match location using the DFA.
+
+Literals in anchored regexes can also be used for detecting non-matches very
+quickly. For example, `^foo\w+` and `\w+foo$` may be able to detect a non-match
+just by examing the first (or last) three bytes of the haystack.
+
+**Advice**: Literals can reduce the work that the regex engine needs to do. Use
+them if you can, especially as prefixes.
+
+## Unicode word boundaries prevent the DFA from being used
+
+It's a sad state of the current implementation. It's not clear when or if
+Unicode word boundaries will be salvaged, but as it stands right now, using
+them automatically disqualifies use of the DFA, which can mean an order of
+magnitude slowdown in search time. There are two ways to ameliorate this:
+
+The first way is to add some number of literal prefixes to your regular
+expression. Even though the DFA won't be used, specialized routines will still
+kick in to find prefix literals quickly, which limits how much work the NFA
+simulation will need to do.
+
+The second way is to give up on Unicode and use an ASCII word boundary instead.
+One can use an ASCII word boundary by disabling Unicode support. That is,
+instead of using `\b`, use `(?-u:\b)`.  Namely, given the regex `\b.+\b`, it
+can be transformed into a regex that uses the DFA with `(?-u:\b).+(?-u:\b)`. It
+is important to limit the scope of disabling the `u` flag, since it might lead
+to a syntax error if the regex could match arbitrary bytes. For example, if one
+wrote `(?-u)\b.+\b`, then a syntax error would be returned because `.` matches
+any *byte* when the Unicode flag is disabled.
+
+N.B. When using `bytes::Regex`, Unicode support is disabled by default, so one
+can simply write `\b` to get an ASCII word boundary.
+
+**Advice**: Use `(?-u:\b)` instead of `\b` if you care about performance more
+than correctness.
+
+## Excessive counting can lead to exponential state blow up in the DFA
+
+Wait, didn't I say that this crate guards against exponential worst cases?
+Well, it turns out that the process of converting an NFA to a DFA can lead to
+an exponential blow up in the number of states. This crate specifically guards
+against exponential blow up by doing two things:
+
+1. The DFA is computed lazily. That is, a state in the DFA only exists in
+   memory if it is visited. In particular, the lazy DFA guarantees that *at
+   most* one state is created for every byte of input. This, on its own,
+   guarantees linear time complexity.
+2. Of course, creating a new state for *every* byte of input means that search
+   will go incredibly slow because of very large constant factors. On top of
+   that, creating a state for every byte in a large haystack could result in
+   exorbitant memory usage. To ameliorate this, the DFA bounds the number of
+   states it can store. Once it reaches its limit, it flushes its cache. This
+   prevents reuse of states that it already computed. If the cache is flushed
+   too frequently, then the DFA will give up and execution will fall back to
+   one of the NFA simulations.
+
+In effect, this crate will detect exponential state blow up and fall back to
+a search routine with fixed memory requirements. This does, however, mean that
+searching will be much slower than one might expect. Regexes that rely on
+counting in particular are strong aggravators of this behavior. For example,
+matching `[01]*1[01]{20}$` against a random sequence of `0`s and `1`s.
+
+In the future, it may be possible to increase the bound that the DFA uses,
+which would allow the caller to choose how much memory they're willing to
+spend.
+
+**Advice**: Don't write regexes that cause DFA state blow up if you care about
+match performance.
+
+## Resist the temptation to "optimize" regexes
+
+An entire book was written on how to optimize Perl-style regular expressions.
+Most of those techniques are not applicable for this library. For example,
+there is no problem with using non-greedy matching or having lots of
+alternations in your regex.
+
+**Advice**: This ain't a backtracking engine.

--- a/benches/src/rust_parse.rs
+++ b/benches/src/rust_parse.rs
@@ -20,6 +20,14 @@ fn parse_simple(b: &mut Bencher) {
 }
 
 #[bench]
+fn parse_simple2(b: &mut Bencher) {
+    b.iter(|| {
+        let re = r"'[a-zA-Z_][a-zA-Z0-9_]*(')\b";
+        Expr::parse(re).unwrap()
+    });
+}
+
+#[bench]
 fn parse_small(b: &mut Bencher) {
     b.iter(|| {
         let re = r"\p{L}|\p{N}|\s|.|\d";

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1004,7 +1004,7 @@ impl ByteClassSet {
         // N.B. If you're debugging the DFA, it's useful to simply return
         // `(0..256).collect()`, which effectively removes the byte classes
         // and makes the transitions easier to read.
-        // return (0..256).collect();
+        // (0usize..256).map(|x| x as u8).collect()
         let mut byte_classes = vec![0; 256];
         let mut class = 0u8;
         for i in 0..256 {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -242,6 +242,7 @@ impl ExecBuilder {
             match_type: MatchType::Nothing,
         };
         ro.match_type = ro.choose_match_type(self.match_type);
+        // println!("MATCH TYPE for '{:?}': {:?}", ro.res, ro.match_type);
 
         let ro = Arc::new(ro);
         let ro_ = ro.clone();

--- a/src/pikevm.rs
+++ b/src/pikevm.rs
@@ -8,22 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// This module implements the "NFA algorithm." That is, it guarantees linear
-// time search of a regex on any text with memory use proportional to the size
-// of the regex.
+// This module implements the Pike VM. That is, it guarantees linear time
+// search of a regex on any text with memory use proportional to the size of
+// the regex.
 //
 // It is equal in power to the backtracking engine in this crate, except the
 // backtracking engine is typically faster on small regexes/texts at the
 // expense of a bigger memory footprint.
 //
 // It can do more than the DFA can (specifically, record capture locations
-// and execute word boundary assertions), but at a slower speed. Specifically,
-// the NFA algorithm exectues a DFA implicitly by repeatedly expanding
-// epsilon transitions. That is, the NFA engine can be in multiple states at
-// once where as the DFA is only ever in one state at a time.
+// and execute Unicode word boundary assertions), but at a slower speed.
+// Specifically, the Pike VM exectues a DFA implicitly by repeatedly expanding
+// epsilon transitions. That is, the Pike VM engine can be in multiple states
+// at once where as the DFA is only ever in one state at a time.
 //
-// Therefore, the NFA algorithm is generally treated as the fallback when the
-// other matching engines either aren't feasible to run or are insufficient.
+// Therefore, the Pike VM is generally treated as the fallback when the other
+// matching engines either aren't feasible to run or are insufficient.
 
 use std::mem;
 

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -128,7 +128,13 @@ impl Program {
         // The only instruction that uses heap space is Ranges (for
         // Unicode codepoint programs) to store non-overlapping codepoint
         // ranges. To keep this operation constant time, we ignore them.
-        self.len() * mem::size_of::<Inst>()
+        (self.len() * mem::size_of::<Inst>())
+        + (self.matches.len() * mem::size_of::<InstPtr>())
+        + (self.captures.len() * mem::size_of::<Option<String>>())
+        + (self.capture_name_idx.len() *
+           (mem::size_of::<String>() + mem::size_of::<usize>()))
+        + (self.byte_classes.len() * mem::size_of::<u8>())
+        + self.prefixes.approximate_size()
     }
 }
 

--- a/tests/test_backtrack.rs
+++ b/tests/test_backtrack.rs
@@ -59,3 +59,5 @@ mod replace;
 mod set;
 mod suffix_reverse;
 mod unicode;
+mod word_boundary;
+mod word_boundary_unicode;

--- a/tests/test_backtrack_bytes.rs
+++ b/tests/test_backtrack_bytes.rs
@@ -61,3 +61,5 @@ mod replace;
 mod set;
 mod suffix_reverse;
 mod unicode;
+mod word_boundary;
+mod word_boundary_ascii;

--- a/tests/test_backtrack_utf8bytes.rs
+++ b/tests/test_backtrack_utf8bytes.rs
@@ -60,3 +60,5 @@ mod replace;
 mod set;
 mod suffix_reverse;
 mod unicode;
+mod word_boundary;
+mod word_boundary_unicode;

--- a/tests/test_default.rs
+++ b/tests/test_default.rs
@@ -70,8 +70,13 @@ mod set;
 mod shortest_match;
 mod suffix_reverse;
 mod unicode;
+mod word_boundary;
+mod word_boundary_unicode;
 
 #[test]
-fn disallow_unicode_flag() {
-    assert!(regex::Regex::new("(?-u)a").is_err());
+fn disallow_non_utf8() {
+    assert!(regex::Regex::new(r"(?-u)\xFF").is_err());
+    assert!(regex::Regex::new(r"(?-u).").is_err());
+    assert!(regex::Regex::new(r"(?-u)[\xFF]").is_err());
+    assert!(regex::Regex::new(r"(?-u)☃").is_err());
 }

--- a/tests/test_default_bytes.rs
+++ b/tests/test_default_bytes.rs
@@ -54,3 +54,5 @@ mod set;
 mod shortest_match;
 mod suffix_reverse;
 mod unicode;
+mod word_boundary;
+mod word_boundary_ascii;

--- a/tests/test_nfa.rs
+++ b/tests/test_nfa.rs
@@ -55,3 +55,5 @@ mod replace;
 mod set;
 mod suffix_reverse;
 mod unicode;
+mod word_boundary;
+mod word_boundary_unicode;

--- a/tests/test_nfa_bytes.rs
+++ b/tests/test_nfa_bytes.rs
@@ -56,3 +56,5 @@ mod replace;
 mod set;
 mod suffix_reverse;
 mod unicode;
+mod word_boundary;
+mod word_boundary_ascii;

--- a/tests/test_nfa_utf8bytes.rs
+++ b/tests/test_nfa_utf8bytes.rs
@@ -56,3 +56,5 @@ mod replace;
 mod set;
 mod suffix_reverse;
 mod unicode;
+mod word_boundary;
+mod word_boundary_unicode;

--- a/tests/word_boundary.rs
+++ b/tests/word_boundary.rs
@@ -1,0 +1,87 @@
+// Many of these are cribbed from RE2's test suite.
+
+matiter!(wb1, r"\b", "");
+matiter!(wb2, r"\b", "a", (0, 0), (1, 1));
+matiter!(wb3, r"\b", "ab", (0, 0), (2, 2));
+matiter!(wb4, r"^\b", "ab", (0, 0));
+matiter!(wb5, r"\b$", "ab", (2, 2));
+matiter!(wb6, r"^\b$", "ab");
+matiter!(wb7, r"\bbar\b", "nobar bar foo bar", (6, 9), (14, 17));
+matiter!(wb8, r"a\b", "faoa x", (3, 4));
+matiter!(wb9, r"\bbar", "bar x", (0, 3));
+matiter!(wb10, r"\bbar", "foo\nbar x", (4, 7));
+matiter!(wb11, r"bar\b", "foobar", (3, 6));
+matiter!(wb12, r"bar\b", "foobar\nxxx", (3, 6));
+matiter!(wb13, r"(foo|bar|[A-Z])\b", "foo", (0, 3));
+matiter!(wb14, r"(foo|bar|[A-Z])\b", "foo\n", (0, 3));
+matiter!(wb15, r"\b(foo|bar|[A-Z])", "foo", (0, 3));
+matiter!(wb16, r"\b(foo|bar|[A-Z])\b", "X", (0, 1));
+matiter!(wb17, r"\b(foo|bar|[A-Z])\b", "XY");
+matiter!(wb18, r"\b(foo|bar|[A-Z])\b", "bar", (0, 3));
+matiter!(wb19, r"\b(foo|bar|[A-Z])\b", "foo", (0, 3));
+matiter!(wb20, r"\b(foo|bar|[A-Z])\b", "foo\n", (0, 3));
+matiter!(wb21, r"\b(foo|bar|[A-Z])\b", "ffoo bbar N x", (10, 11));
+matiter!(wb22, r"\b(fo|foo)\b", "fo", (0, 2));
+matiter!(wb23, r"\b(fo|foo)\b", "foo", (0, 3));
+matiter!(wb24, r"\b\b", "");
+matiter!(wb25, r"\b\b", "a", (0, 0), (1, 1));
+matiter!(wb26, r"\b$", "");
+matiter!(wb27, r"\b$", "x", (1, 1));
+matiter!(wb28, r"\b$", "y x", (3, 3));
+matiter!(wb29, r"\b.$", "x", (0, 1));
+matiter!(wb30, r"^\b(fo|foo)\b", "fo", (0, 2));
+matiter!(wb31, r"^\b(fo|foo)\b", "foo", (0, 3));
+matiter!(wb32, r"^\b$", "");
+matiter!(wb33, r"^\b$", "x");
+matiter!(wb34, r"^\b.$", "x", (0, 1));
+matiter!(wb35, r"^\b.\b$", "x", (0, 1));
+matiter!(wb36, r"^^^^^\b$$$$$", "");
+matiter!(wb37, r"^^^^^\b.$$$$$", "x", (0, 1));
+matiter!(wb38, r"^^^^^\b$$$$$", "x");
+matiter!(wb39, r"^^^^^\b\b\b.\b\b\b$$$$$", "x", (0, 1));
+
+matiter!(nb1, r"\Bfoo\B", "n foo xfoox that", (7, 10));
+matiter!(nb2, r"a\B", "faoa x", (1, 2));
+matiter!(nb3, r"\Bbar", "bar x");
+matiter!(nb4, r"\Bbar", "foo\nbar x");
+matiter!(nb5, r"bar\B", "foobar");
+matiter!(nb6, r"bar\B", "foobar\nxxx");
+matiter!(nb7, r"(foo|bar|[A-Z])\B", "foox", (0, 3));
+matiter!(nb8, r"(foo|bar|[A-Z])\B", "foo\n");
+matiter!(nb9, r"\B", "", (0, 0));
+matiter!(nb10, r"\B", "x");
+matiter!(nb11, r"\B(foo|bar|[A-Z])", "foo");
+matiter!(nb12, r"\B(foo|bar|[A-Z])\B", "xXy", (1, 2));
+matiter!(nb13, r"\B(foo|bar|[A-Z])\B", "XY");
+matiter!(nb14, r"\B(foo|bar|[A-Z])\B", "XYZ", (1, 2));
+matiter!(nb15, r"\B(foo|bar|[A-Z])\B", "abara", (1, 4));
+matiter!(nb16, r"\B(foo|bar|[A-Z])\B", "xfoo_", (1, 4));
+matiter!(nb17, r"\B(foo|bar|[A-Z])\B", "xfoo\n");
+matiter!(nb18, r"\B(foo|bar|[A-Z])\B", "foo bar vNX", (9, 10));
+matiter!(nb19, r"\B(fo|foo)\B", "xfoo", (1, 3));
+matiter!(nb20, r"\B(foo|fo)\B", "xfooo", (1, 4));
+matiter!(nb21, r"\B\B", "", (0, 0));
+matiter!(nb22, r"\B\B", "x");
+matiter!(nb23, r"\B$", "", (0, 0));
+matiter!(nb24, r"\B$", "x");
+matiter!(nb25, r"\B$", "y x");
+matiter!(nb26, r"\B.$", "x");
+matiter!(nb27, r"^\B(fo|foo)\B", "fo");
+matiter!(nb28, r"^\B(fo|foo)\B", "foo");
+matiter!(nb29, r"^\B", "", (0, 0));
+matiter!(nb30, r"^\B", "x");
+matiter!(nb31, r"^\B\B", "", (0, 0));
+matiter!(nb32, r"^\B\B", "x");
+matiter!(nb33, r"^\B$", "", (0, 0));
+matiter!(nb34, r"^\B$", "x");
+matiter!(nb35, r"^\B.$", "x");
+matiter!(nb36, r"^\B.\B$", "x");
+matiter!(nb37, r"^^^^^\B$$$$$", "", (0, 0));
+matiter!(nb38, r"^^^^^\B.$$$$$", "x");
+matiter!(nb39, r"^^^^^\B$$$$$", "x");
+
+// These work for both Unicode and ASCII because all matches are reported as
+// byte offsets, and « and » do not correspond to word boundaries at either
+// the character or byte level.
+matiter!(unicode1, r"\bx\b", "«x", (2, 3));
+matiter!(unicode2, r"\bx\b", "x»", (0, 1));

--- a/tests/word_boundary_ascii.rs
+++ b/tests/word_boundary_ascii.rs
@@ -1,0 +1,8 @@
+// ASCII word boundaries are completely oblivious to Unicode characters.
+// For Unicode word boundaries, the tests are precisely inverted.
+matiter!(ascii1, r"\bx\b", "áxβ", (2, 3));
+matiter!(ascii2, r"\Bx\B", "áxβ");
+
+// We can still get Unicode mode in byte regexes.
+matiter!(unicode1, r"(?u:\b)x(?u:\b)", "áxβ");
+matiter!(unicode2, r"(?u:\B)x(?u:\B)", "áxβ", (2, 3));

--- a/tests/word_boundary_unicode.rs
+++ b/tests/word_boundary_unicode.rs
@@ -1,0 +1,7 @@
+// Unicode word boundaries know about Unicode characters.
+// For ASCII word boundaries, the tests are precisely inverted.
+matiter!(unicode1, r"\bx\b", "áxβ");
+matiter!(unicode2, r"\Bx\B", "áxβ", (2, 3));
+
+matiter!(ascii1, r"(?-u:\b)x(?-u:\b)", "áxβ", (2, 3));
+matiter!(ascii2, r"(?-u:\B)x(?-u:\B)", "áxβ");


### PR DESCRIPTION
In other words, `\b` in a `bytes::Regex` can now be used in the DFA.
This leads to a big performance boost:

```
sherlock::word_ending_n                  115,465,261 (5 MB/s)  3,038,621 (195 MB/s)    -112,426,640  -97.37%
```

Unfortunately, Unicode word boundaries continue to elude the DFA. This
state of affairs is lamentable, but after a lot of thought, I've
concluded there are only two ways to speed up Unicode word boundaries:

1. Come up with a hairbrained scheme to add multi-byte look-behind/ahead
   to the lazy DFA. (The theory says it's possible. Figuring out how to
   do this without combinatorial state explosion is not within my grasp
   at the moment.)
2. Build a second lazy DFA with transitions on Unicode codepoints
   instead of bytes. (The looming inevitability of this makes me queasy
   for a number of reasons.)

To ameliorate this state of affairs, it is now possible to disable
Unicode support in `Regex::new` with `(?-u)`. In other words, one can
now use an ASCII word boundary with `(?-u:\b)`.

Disabling Unicode support does not violate any invariants around UTF-8.
In particular, if the regular expression could lead to a match of
invalid UTF-8, then the parser will return an error. (This only happens
for `Regex::new`. `bytes::Regex::new` still of course allows matching
arbitrary bytes.)

Finally, a new `PERFORMANCE.md` guide was written.