### PR TITLE
Fix undefined behavior in regex_macros

### DIFF
--- a/regex_macros/src/lib.rs
+++ b/regex_macros/src/lib.rs
@@ -309,7 +309,7 @@ fn exec<'t>(
 
         #[inline]
         fn contains(&self, pc: usize) -> bool {
-            let s = self.sparse[pc];
+            let s = unsafe { ::std::ptr::read_volatile(&self.sparse[pc]) };
             s < self.size && self.dense[s].pc == pc
         }
 


### PR DESCRIPTION
The value read in `contains` may be uninitialized, and using such a value is undefined behavior. In particular with LLVM, where `s` is `undef` and can return a different value each time it is read. The solution is to use a volatile load to ensure we already get a real value, not an `undef`.