### PR TITLE
More improvements to the DFA's inner loop.

### DIFF
--- a/src/prog.rs
+++ b/src/prog.rs
@@ -68,7 +68,7 @@ impl Program {
             captures: vec![],
             capture_name_idx: Arc::new(HashMap::new()),
             start: 0,
-            byte_classes: vec![],
+            byte_classes: vec![0; 256],
             only_utf8: true,
             is_bytes: false,
             is_dfa: false,


### PR DESCRIPTION
There were two important changes:

  1. self.at is used sparingly in favor of a local `let at` binding.
     This seems to convince the compiler to use a register.
  2. Switch the transition table from a `Vec<Box<[StatePtr]>>` to a
     row-major `Vec<StatePtr>`.

(2) is the juicier of the two. It makes more efficient use of the cache.
In particular, a critical aspect is that a StatePtr points to the start
of a row in the table, which enables indexing in the inner loop with a
single ADD instruction. (i.e., `si + byte` instead of
`si * #classes + byte`.)