### PR TITLE
Revert "Replace mempool with thread_local"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.6.0
+  - 1.3.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ aho-corasick = "0.5.1"
 # For skipping along search text quickly when a leading byte is known.
 memchr = "0.1.9"
 # For managing regex caches quickly across multiple threads.
-thread_local = "0.2.0"
+mempool = "0.3.0"
 # For parsing regular expressions.
 regex-syntax = { path = "regex-syntax", version = "0.3.1" }
 # For compiling UTF-8 decoding into automata.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,7 +505,7 @@
 
 extern crate aho_corasick;
 extern crate memchr;
-extern crate thread_local;
+extern crate mempool;
 #[cfg(test)] extern crate quickcheck;
 extern crate regex_syntax as syntax;
 extern crate utf8_ranges;


### PR DESCRIPTION
This caused regex to require Rust 1.6, which really should require a
semver bump since it will break existing code. For now, we'll stick with
mempool and move to the faster thread_local version on the next semver
bump (hopefully 1.0).

Fixes #206