### PR TITLE
Fixes a performance bug in bytes::Regex::replace.

### DIFF
--- a/examples/shootout-regex-dna-bytes.rs
+++ b/examples/shootout-regex-dna-bytes.rs
@@ -14,7 +14,7 @@ use std::thread;
 macro_rules! regex { ($re:expr) => { ::regex::bytes::Regex::new($re).unwrap() } }
 
 fn main() {
-    let mut seq = Vec::with_capacity(50 * (1 << 20));
+    let mut seq = Vec::with_capacity(51 * (1 << 20));
     io::stdin().read_to_end(&mut seq).unwrap();
     let ilen = seq.len();
 

--- a/examples/shootout-regex-dna.rs
+++ b/examples/shootout-regex-dna.rs
@@ -14,7 +14,7 @@ use std::thread;
 macro_rules! regex { ($re:expr) => { ::regex::Regex::new($re).unwrap() } }
 
 fn main() {
-    let mut seq = String::with_capacity(50 * (1 << 20));
+    let mut seq = String::with_capacity(51 * (1 << 20));
     io::stdin().read_to_string(&mut seq).unwrap();
     let ilen = seq.len();
 


### PR DESCRIPTION
This was using `Vec::extend` to accumulate bytes in a buffer, but this
compiles down to less efficient code than, say, `Vec::extend_from_slice`.
However, that method is newly available as of Rust 1.6, so we do a small
backport to regain performance.

This bug was noticed by @llogiq here: https://github.com/TeXitoi/benchmarksgame-rs/issues/31
In particular, this increases the performance of bytes::Regex two-fold on
that benchmark.