### PR TITLE
Add known upper limit to capture search.

### DIFF
--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -19,6 +19,25 @@ const TAG_TWO: u8 = 0b1100_0000;
 const TAG_THREE: u8 = 0b1110_0000;
 const TAG_FOUR: u8 = 0b1111_0000;
 
+/// Returns the smallest possible index of the next valid UTF-8 sequence
+/// starting after `i`.
+pub fn next_utf8(text: &[u8], i: usize) -> usize {
+    let b = match text.get(i) {
+        None => return i + 1,
+        Some(&b) => b,
+    };
+    let inc = if b <= 0x7F {
+        1
+    } else if b <= 0b110_11111 {
+        2
+    } else if b <= 0b1110_1111 {
+        3
+    } else {
+        4
+    };
+    i + inc
+}
+
 /// Encode the given Unicode character to `dst` as a single UTF-8 sequence.
 ///
 /// If `dst` is not long enough, then `None` is returned. Otherwise, the number


### PR DESCRIPTION
The DFA will report the end location of a match, so we should pass that
along to capture detection. In theory, the DFA and the NFA report the
same match locations, so this upper bound shouldn't be necessary---the
NFA should quit once it finds the right match. It turns out though
bounding the text has two important ramifications:

1. It will enable the backtracking engine to be used more often. In
particular, the backtracking engine can only be used on small inputs and
this change decreases the size of the input by only considering the
match.
2. The backtracking engine must start every search by zeroing memory
that is proportional to the size of the input. If the input is smaller,
then this runs more quickly.

We are also careful to bound the match to one additional "character"
past the end of the match, so that lookahead operators work correctly.

See also: #215.