### PR TITLE
Rename some methods on SparseSet to better match sets in the standard…

### DIFF
--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -833,7 +833,7 @@ impl<'a> Fsm<'a> {
         // Initialize a queue with the current DFA state's NFA states.
         qcur.clear();
         for &ip in self.state(si).insts.iter() {
-            qcur.add(ip as usize);
+            qcur.insert(ip as usize);
         }
 
         // Before inspecting the current byte, we may need to also inspect
@@ -900,10 +900,10 @@ impl<'a> Fsm<'a> {
                     if !self.continue_past_first_match() {
                         break;
                     } else if self.prog.matches.len() > 1
-                            && !qnext.contains_ip(ip as usize) {
+                            && !qnext.contains(ip as usize) {
                         // If we are continuing on to find other matches,
                         // then keep a record of the match states we've seen.
-                        qnext.add(ip);
+                        qnext.insert(ip);
                     }
                 }
                 Bytes(ref inst) => {
@@ -994,10 +994,10 @@ impl<'a> Fsm<'a> {
         self.cache.stack.push(ip);
         while let Some(ip) = self.cache.stack.pop() {
             // Don't visit states we've already added.
-            if q.contains_ip(ip as usize) {
+            if q.contains(ip as usize) {
                 continue;
             }
-            q.add(ip as usize);
+            q.insert(ip as usize);
             match self.prog[ip as usize] {
                 Char(_) | Ranges(_) => unreachable!(),
                 Match(_) | Bytes(_) => {}

--- a/src/pikevm.rs
+++ b/src/pikevm.rs
@@ -316,10 +316,10 @@ impl<'r, I: Input> Fsm<'r, I> {
         use prog::Inst::*;
         loop {
             // Don't visit states we've already added.
-            if nlist.set.contains_ip(ip) {
+            if nlist.set.contains(ip) {
                 return;
             }
-            nlist.set.add(ip);
+            nlist.set.insert(ip);
             match self.prog[ip] {
                 EmptyLook(ref inst) => {
                     let prev = self.input.previous_char(at);

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -11,10 +11,6 @@ use std::slice;
 /// Note though that we don't actually use unitialized memory. We generally
 /// reuse allocations, so the initial allocation cost is bareable. However,
 /// its other properties listed above are extremely useful.
-///
-/// N.B. The type parameter is misleading. For the most part, this is only
-/// meant to work on instruction pointers. We use a touch of generics to
-/// support 32 bit instruction pointers.
 #[derive(Clone, Debug)]
 pub struct SparseSet {
     /// Dense contains the instruction pointers in the order in which they
@@ -50,16 +46,16 @@ impl SparseSet {
         self.dense.len()
     }
 
-    pub fn add(&mut self, ip: usize) {
+    pub fn insert(&mut self, value: usize) {
         let i = self.size;
-        self.dense[i] = ip;
-        self.sparse[ip] = i;
+        self.dense[i] = value;
+        self.sparse[value] = i;
         self.size += 1;
     }
 
-    pub fn contains_ip(&self, ip: usize) -> bool {
-        let i = self.sparse[ip];
-        i < self.size && self.dense[i] == ip
+    pub fn contains(&self, value: usize) -> bool {
+        let i = self.sparse[value];
+        i < self.size && self.dense[i] == value
     }
 
     pub fn clear(&mut self) {


### PR DESCRIPTION
… library.

This also removes a comment that seems to be outdated.