### PR TITLE
Minor perf improvements and code touch ups.

### DIFF
--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -59,9 +59,19 @@ pub use ffi::tcl::Regex;
 // Due to macro scoping rules, this definition only applies for the modules
 // defined below. Effectively, it allows us to use the same tests for both
 // native and dynamic regexes.
+#[cfg(not(feature = "re-rust-bytes"))]
 #[cfg(not(feature = "re-rust-plugin"))]
 macro_rules! regex {
     ($re:expr) => { ::Regex::new($re).unwrap() }
+}
+
+#[cfg(feature = "re-rust-bytes")]
+#[cfg(not(feature = "re-rust-plugin"))]
+macro_rules! regex {
+    ($re:expr) => {{
+        use regex::bytes::RegexBuilder;
+        RegexBuilder::new($re).unicode(true).compile().unwrap()
+    }}
 }
 
 // Usage: text!(haystack)

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -69,6 +69,8 @@ macro_rules! regex {
 #[cfg(not(feature = "re-rust-plugin"))]
 macro_rules! regex {
     ($re:expr) => {{
+        // Always enable the Unicode flag for byte based regexes.
+        // Really, this should have been enabled by default. *sigh*
         use regex::bytes::RegexBuilder;
         RegexBuilder::new($re).unicode(true).compile().unwrap()
     }}

--- a/bench/src/sherlock.rs
+++ b/bench/src/sherlock.rs
@@ -101,32 +101,17 @@ sherlock!(everything_greedy_nl, r"(?s).*", 1);
 // How fast can we match every letter? This also defeats any clever prefix
 // tricks.
 #[cfg(not(feature = "re-tcl"))]
-#[cfg(not(feature = "re-rust-bytes"))]
 sherlock!(letters, r"\p{L}", 447160);
-#[cfg(not(feature = "re-tcl"))]
-#[cfg(feature = "re-rust-bytes")]
-sherlock!(letters, r"(?u)\p{L}", 447160);
 
 #[cfg(not(feature = "re-tcl"))]
-#[cfg(not(feature = "re-rust-bytes"))]
 sherlock!(letters_upper, r"\p{Lu}", 14180);
-#[cfg(not(feature = "re-tcl"))]
-#[cfg(feature = "re-rust-bytes")]
-sherlock!(letters_upper, r"(?u)\p{Lu}", 14180);
 
 #[cfg(not(feature = "re-tcl"))]
-#[cfg(not(feature = "re-rust-bytes"))]
 sherlock!(letters_lower, r"\p{Ll}", 432980);
-#[cfg(not(feature = "re-tcl"))]
-#[cfg(feature = "re-rust-bytes")]
-sherlock!(letters_lower, r"(?u)\p{Ll}", 432980);
 
 // Similarly, for words.
-#[cfg(not(feature = "re-rust-bytes"))]
 #[cfg(not(feature = "re-re2"))]
 sherlock!(words, r"\w+", 109214);
-#[cfg(feature = "re-rust-bytes")]
-sherlock!(words, r"(?u)\w+", 109214);
 #[cfg(feature = "re-re2")]
 sherlock!(words, r"\w+", 109222); // hmm, why does RE2 diverge here?
 
@@ -195,8 +180,4 @@ sherlock!(ing_suffix, r"[a-zA-Z]+ing", 2824);
 //
 // Onig does surprisingly well on this benchmark and yet does quite poorly on
 // the ing_suffix benchmark. That one has me stumped.
-//
-// Interestingly, this is slower in the rust-bytes benchmark, presumably
-// because scanning for one of the bytes in the Unicode *unaware* `\s` ends
-// up being slower than avoiding the prefix scan at all.
 sherlock!(ing_suffix_limited_space, r"\s[a-zA-Z]{0,12}ing\s", 2081);

--- a/src/literals.rs
+++ b/src/literals.rs
@@ -361,8 +361,8 @@ pub struct SingleSearch {
     /// The second rarest byte is used as a type of guard for quickly detecting
     /// a mismatch after memchr locates an instance of the rarest byte. This
     /// is a hedge against pathological cases where the pre-computed frequency
-    /// analysis may be off. (But of course, does not prevent pathological
-    /// cases.)
+    /// analysis may be off. (But of course, does not prevent *all*
+    /// pathological cases.)
     rare2: u8,
     /// The offset of the second rarest byte in `pat`.
     rare2i: usize,

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -132,7 +132,7 @@ impl Program {
     /// Returns true if this program uses Byte instructions instead of
     /// Char/Range instructions.
     pub fn uses_bytes(&self) -> bool {
-        self.is_bytes || self.is_dfa || !self.only_utf8
+        self.is_bytes || self.is_dfa
     }
 
     /// Returns true if this program exclusively matches valid UTF-8 bytes.


### PR DESCRIPTION
1. Use Unicode instructions in a `bytes::Regex` more aggressively. We could do more on this front. Unicode instructions are quite a bit faster for the NFA engines to execute.
2. Remove the DFA's `StateKey` type, since it is exactly equivalent to `State`.