### PR TITLE
Fix #186.

### DIFF
--- a/src/prog.rs
+++ b/src/prog.rs
@@ -289,6 +289,16 @@ pub enum Inst {
     Bytes(InstBytes),
 }
 
+impl Inst {
+    /// Returns true if and only if this is a match instruction.
+    pub fn is_match(&self) -> bool {
+        match *self {
+            Inst::Match(_) => true,
+            _ => false,
+        }
+    }
+}
+
 /// Representation of the Save instruction.
 #[derive(Clone, Debug)]
 pub struct InstSave {


### PR DESCRIPTION
This enables RegexSets to short-circuit when:

1. All patterns are anchored to the beginning of the input.
2. All patterns have either matched or will never match.

We make this happen by checking whether all NFA states in a DFA state
are match states, when a DFA match is observed. If all NFA states are
match states, and since all match states are final states, we know that
the current set of matches will never change. Since we don't care about
reporting location information, we can quit.

N.B. If no matches can be found, then the DFA will short circuit using its
normal mechanism.