### PR TITLE
Clarify documentation for the regex! plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,13 @@ assert!(matches.matched(6));
 
 ### Usage: `regex!` compiler plugin
 
+**WARNING**: The `regex!` compiler plugin is orders of magnitude slower than
+the normal `Regex::new(...)` usage. You should not use the compiler plugin
+unless you have a very special reason for doing so. The performance difference
+may be the temporary, but the path forward at this point isn't clear.
+
 The `regex!` compiler plugin will compile your regexes at compile time. **This
 only works with a nightly compiler.**
-The
-[documentation explains the trade
-offs](https://doc.rust-lang.org/regex/regex/index.html#the-regex!-macro).
 
 Here is a small example:
 
@@ -221,10 +223,6 @@ fn main() {
 Notice that we never `unwrap` the result of `regex!`. This is because your
 *program* won't compile if the regex doesn't compile. (Try `regex!("(")`.)
 
-Due to recent optimizations in the `regex` crate, the normal "dynamic" regex
-created via `Regex::new(...)` is faster in almost all cases than `regex!(...)`.
-In theory, this should be temporary, but the path to fixing it isn't quite
-clear yet.
 
 ### Usage: a regular expression parser
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,56 +94,6 @@
 //! Specifically, in this example, the regex will be compiled when it is used for
 //! the first time. On subsequent uses, it will reuse the previous compilation.
 //!
-//! # The `regex!` macro
-//!
-//! Rust's compile-time meta-programming facilities provide a way to write a
-//! `regex!` macro which compiles regular expressions *when your program
-//! compiles*. Said differently, if you only use `regex!` to build regular
-//! expressions in your program, then your program cannot compile with an
-//! invalid regular expression. Moreover, the `regex!` macro compiles the
-//! given expression to native Rust code, which ideally makes it faster.
-//! Unfortunately (or fortunately), the dynamic implementation has had a lot
-//! more optimization work put into it currently, so it is faster than
-//! the `regex!` macro in almost every case.
-//!
-//! To use the `regex!` macro, you must add `regex_macros` to your dependencies
-//! in your project's `Cargo.toml`:
-//!
-//! ```toml
-//! [dependencies]
-//! regex = "0.1"
-//! regex_macros = "0.1"
-//! ```
-//!
-//! and then enable the `plugin` feature and import the `regex_macros` crate as
-//! a syntax extension:
-//!
-//! ```ignore
-//! #![feature(plugin)]
-//! #![plugin(regex_macros)]
-//! extern crate regex;
-//!
-//! fn main() {
-//!     let re = regex!(r"^\d{4}-\d{2}-\d{2}$");
-//!     assert!(re.is_match("2014-01-01"));
-//! }
-//! ```
-//!
-//! There are a few things worth mentioning about using the `regex!` macro.
-//! Firstly, the `regex!` macro *only* accepts string *literals*.
-//! Secondly, the `regex` crate *must* be linked with the name `regex` since
-//! the generated code depends on finding symbols in the `regex` crate.
-//!
-//! One downside of using the `regex!` macro is that it can increase the
-//! size of your program's binary since it generates specialized Rust code.
-//! The extra size probably won't be significant for a small number of
-//! expressions, but 100+ calls to `regex!` will probably result in a
-//! noticeably bigger binary.
-//!
-//! **NOTE**: This is implemented using a compiler plugin, which is not
-//! available on the Rust 1.0 beta/stable channels. Therefore, you'll only
-//! be able to use `regex!` on the nightly Rust releases.
-//!
 //! # Example: iterating over capture groups
 //!
 //! This crate provides convenient iterators for matching an expression


### PR DESCRIPTION
At least one person has pointed to this section in the documentation for
justification of using it. One might make the very reasonable assumption
that since the regex is compiled at compile time, it will be faster.
This assumption is (very) wrong. Because of that, and because there's
almost no reason I can think of to use `regex!` at this point (perhaps one
values compile time validation very highly?), we should just remove it from
the docs altogether.