### PR TITLE
Reintroduce the reverse suffix literal optimization.

### DIFF
--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
                                        .unwrap_or_else(|e| e.exit());
 
     let mmap = Mmap::open_path(&args.arg_file, Protection::Read).unwrap();
-    let haystack = unsafe { str::from_utf8(mmap.as_slice()).unwrap() };
+    let haystack = unsafe { str::from_utf8_unchecked(mmap.as_slice()) };
 
     println!("{}", args.count(&haystack));
 }

--- a/bench/src/misc.rs
+++ b/bench/src/misc.rs
@@ -92,6 +92,14 @@ bench_match!(long_needle2, r"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbba", {
     repeat("b").take(100_000).collect::<String>() + "a"
 });
 
+// This benchmark specifically targets the "reverse suffix literal"
+// optimization. In particular, it is easy for a naive implementation to
+// take quadratic worst case time. This benchmark provides a case for such
+// a scenario.
+bench_not_match!(reverse_suffix_no_quadratic, r"[r-z].*bcdefghijklmnopq", {
+    repeat("bcdefghijklmnopq").take(500).collect::<String>()
+});
+
 #[cfg(feature = "re-rust")]
 #[bench]
 fn replace_all(b: &mut Bencher) {

--- a/src/literals.rs
+++ b/src/literals.rs
@@ -457,6 +457,10 @@ impl SingleSearch {
         self.pat.len()
     }
 
+    pub fn char_len(&self) -> usize {
+        self.char_len
+    }
+
     fn approximate_size(&self) -> usize {
         self.pat.len() * mem::size_of::<u8>()
     }

--- a/tests/suffix_reverse.rs
+++ b/tests/suffix_reverse.rs
@@ -8,15 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// N.B. These tests were specifically for the reverse suffix literal
-// optimization. That optimization has since been removed because its worst
-// case time complexity is quadratic. There is hope for bringing it back, so
-// we leave these tests here.
-
 mat!(t01, r".*abcd", r"abcd", Some((0, 4)));
 mat!(t02, r".*(?:abcd)+", r"abcd", Some((0, 4)));
 mat!(t03, r".*(?:abcd)+", r"abcdabcd", Some((0, 8)));
 mat!(t04, r".*(?:abcd)+", r"abcdxabcd", Some((0, 9)));
 mat!(t05, r".*x(?:abcd)+", r"abcdxabcd", Some((0, 9)));
 mat!(t06, r"[^abcd]*x(?:abcd)+", r"abcdxabcd", Some((4, 9)));
-mat!(t07, r".*(?:abcd)+", r"abcdabcd", Some((0, 8)));
+// mat!(t05, r".*(?:abcd)+", r"abcdabcd", Some((0, 4)));


### PR DESCRIPTION
It's too good to pass up. This time, we avoid quadratic behavior
with a simple work-around: we limit the amount of reverse searching
we do after having found a literal match. If the reverse search ends
at the beginning of its search text (whether a match or not), then we
stop the reverse suffix optimization and fall back to the standard forward
search.

A benchmark was added that will experience serious slow downs if
quadratic behavior happens.

This reverts commit 50d991eaf53e6c21b8101c82e01ab6cf36fe687c.