### PR TITLE
Use variable width integer encoding for compression

### DIFF
--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -62,7 +62,7 @@ pub use ffi::tcl::Regex;
 #[cfg(not(feature = "re-rust-bytes"))]
 #[cfg(not(feature = "re-rust-plugin"))]
 macro_rules! regex {
-    ($re:expr) => { ::Regex::new($re).unwrap() }
+    ($re:expr) => { ::Regex::new(&$re.to_owned()).unwrap() }
 }
 
 #[cfg(feature = "re-rust-bytes")]
@@ -72,7 +72,7 @@ macro_rules! regex {
         // Always enable the Unicode flag for byte based regexes.
         // Really, this should have been enabled by default. *sigh*
         use regex::bytes::RegexBuilder;
-        RegexBuilder::new($re).unicode(true).compile().unwrap()
+        RegexBuilder::new(&$re.to_owned()).unicode(true).compile().unwrap()
     }}
 }
 

--- a/bench/src/misc.rs
+++ b/bench/src/misc.rs
@@ -16,19 +16,16 @@ use test::Bencher;
 
 use {Regex, Text};
 
-/*
 #[cfg(not(feature = "re-onig"))]
 #[cfg(not(feature = "re-pcre1"))]
 #[cfg(not(feature = "re-pcre2"))]
 #[cfg(not(feature = "re-rust-plugin"))]
 bench_match!(no_exponential, {
-    let re = format!(
+    format!(
         "{}{}",
         repeat("a?").take(100).collect::<String>(),
-        repeat("a").take(100).collect::<String>());
-    regex!(&re)
+        repeat("a").take(100).collect::<String>())
 }, repeat("a").take(100).collect());
-*/
 
 bench_match!(literal, r"y", {
    format!("{}y", repeat("x").take(50).collect::<String>())

--- a/bench/src/sherlock.rs
+++ b/bench/src/sherlock.rs
@@ -119,6 +119,10 @@ sherlock!(words, r"\w+", 109222); // hmm, why does RE2 diverge here?
 // optimizations.
 sherlock!(before_holmes, r"\w+\s+Holmes", 319);
 
+// Find complete words before Holmes. Both of the `\w`s defeat any prefix
+// and suffix optimizations.
+sherlock!(before_after_holmes, r"\w+\s+Holmes\s+\w+", 137);
+
 // Find Holmes co-occuring with Watson in a particular window of characters.
 // This uses Aho-Corasick for the Holmes|Watson prefix, but the lazy DFA for
 // the rest.

--- a/tests/suffix_reverse.rs
+++ b/tests/suffix_reverse.rs
@@ -14,4 +14,3 @@ mat!(t03, r".*(?:abcd)+", r"abcdabcd", Some((0, 8)));
 mat!(t04, r".*(?:abcd)+", r"abcdxabcd", Some((0, 9)));
 mat!(t05, r".*x(?:abcd)+", r"abcdxabcd", Some((0, 9)));
 mat!(t06, r"[^abcd]*x(?:abcd)+", r"abcdxabcd", Some((4, 9)));
-// mat!(t05, r".*(?:abcd)+", r"abcdabcd", Some((0, 4)));


### PR DESCRIPTION
This slightly modifies the implementation in #226 to use variable width
integers. This saves a touch more space with regexes with huge
alternations spanning larger-than-127 instructions (typically from Unicode
character classes).

This also adjusts `approximate_size`, which is the actual gatekeeper
behind deciding whether the DFA has filled its cache or not. The approximation
is now reduced slightly to account for the space savings.

The variable integer encoding used is from Protocol Buffers, documented
here: https://developers.google.com/protocol-buffers/docs/encoding#varints