### PR TITLE
Fixes #234.

### DIFF
--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -1,4 +1,7 @@
 mat!(uni_literal, u!(r"☃"), "☃", Some((0, 3)));
+mat!(uni_literal_plus, u!(r"☃+"), "☃", Some((0, 3)));
+mat!(uni_literal_casei_plus, u!(r"(?i)☃+"), "☃", Some((0, 3)));
+mat!(uni_class_plus, u!(r"[☃Ⅰ]+"), "☃", Some((0, 3)));
 mat!(uni_one, u!(r"\pN"), "Ⅰ", Some((0, 3)));
 mat!(uni_mixed, u!(r"\pN+"), "Ⅰ1Ⅱ2", Some((0, 8)));
 mat!(uni_not, u!(r"\PN+"), "abⅠ", Some((0, 2)));


### PR DESCRIPTION
It turns out that we weren't compute suffix literals correctly in all
cases. In particular, the bytes from a Unicode character were being
reversed.