### PR TITLE
Replace `^` (xor) on bools with `!=` and `==`.

### DIFF
--- a/src/prog.rs
+++ b/src/prog.rs
@@ -361,22 +361,10 @@ impl InstEmptyLook {
             EndLine => c2.is_none() || c2 == '\n',
             StartText => c1.is_none(),
             EndText => c2.is_none(),
-            WordBoundary => {
-                let (w1, w2) = (c1.is_word_char(), c2.is_word_char());
-                w1 ^ w2
-            }
-            NotWordBoundary => {
-                let (w1, w2) = (c1.is_word_char(), c2.is_word_char());
-                !(w1 ^ w2)
-            }
-            WordBoundaryAscii => {
-                let (w1, w2) = (c1.is_word_byte(), c2.is_word_byte());
-                w1 ^ w2
-            }
-            NotWordBoundaryAscii => {
-                let (w1, w2) = (c1.is_word_byte(), c2.is_word_byte());
-                !(w1 ^ w2)
-            }
+            WordBoundary => c1.is_word_char() != c2.is_word_char(),
+            NotWordBoundary => c1.is_word_char() == c2.is_word_char(),
+            WordBoundaryAscii => c1.is_word_byte() != c2.is_word_byte(),
+            NotWordBoundaryAscii => c1.is_word_byte() == c2.is_word_byte(),
         }
     }
 }


### PR DESCRIPTION
Just a tiny refactoring for readability and concision.