### PR TITLE
Touch up benchmarks.

### DIFF
--- a/bench/compile
+++ b/bench/compile
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Enable SIMD.
-export RUSTFLAGS="-C target-feature=+ssse3"
+export RUSTFLAGS="-C target-cpu=native"
 
 exec cargo build \
   --release \

--- a/bench/run
+++ b/bench/run
@@ -10,7 +10,8 @@ if [ $# = 0 ] || [ $1 = '-h' ] || [ $1 = '--help' ]; then
 fi
 
 # Enable SIMD.
-export RUSTFLAGS="-C target-feature=+ssse3"
+# export RUSTFLAGS="-C target-feature=+ssse3"
+export RUSTFLAGS="-C target-cpu=native"
 
 which="$1"
 shift

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -66,7 +66,6 @@ macro_rules! regex {
 }
 
 #[cfg(feature = "re-rust-bytes")]
-#[cfg(not(feature = "re-rust-plugin"))]
 macro_rules! regex {
     ($re:expr) => {{
         // Always enable the Unicode flag for byte based regexes.
@@ -250,4 +249,5 @@ macro_rules! bench_find {
 
 mod ffi;
 mod misc;
+mod regexdna;
 mod sherlock;

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -45,7 +45,7 @@ Since this tool includes compilation of the <pattern>, sufficiently large
 haystacks should be used to amortize the cost of compilation. (e.g., >1MB.)
 
 Usage:
-    regex-run-one [options] [onig | pcre1 | pcre2 | re2 | rust | rust-bytes | tcl] <pattern> <file>
+    regex-run-one [options] [onig | pcre1 | pcre2 | re2 | rust | rust-bytes | tcl] <file> <pattern>
     regex-run-one [options] (-h | --help)
 
 Options:

--- a/bench/src/regexdna.rs
+++ b/bench/src/regexdna.rs
@@ -1,0 +1,47 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use test::Bencher;
+
+use {Regex, Text};
+
+// USAGE: dna!(name, pattern, count)
+//
+// This is same as bench_find, except it always uses the regexdna haystack.
+macro_rules! dna {
+    ($name:ident, $pattern:expr, $count:expr) => {
+        bench_find!(
+            $name, $pattern, $count,
+            include_str!("data/regexdna.txt").to_owned()
+        );
+    }
+}
+
+dna!(find_new_lines, r">[^\n]*\n|\n", 83337);
+dna!(variant1, r"agggtaaa|tttaccct", 32);
+dna!(variant2, r"[cgt]gggtaaa|tttaccc[acg]", 115);
+dna!(variant3, r"a[act]ggtaaa|tttacc[agt]t", 368);
+dna!(variant4, r"ag[act]gtaaa|tttac[agt]ct", 254);
+dna!(variant5, r"agg[act]taaa|ttta[agt]cct", 466);
+dna!(variant6, r"aggg[acg]aaa|ttt[cgt]ccct", 135);
+dna!(variant7, r"agggt[cgt]aa|tt[acg]accct", 137);
+dna!(variant8, r"agggta[cgt]a|t[acg]taccct", 139);
+dna!(variant9, r"agggtaa[cgt]|[acg]ttaccct", 197);
+dna!(subst1, r"B", 29963);
+dna!(subst2, r"D", 29987);
+dna!(subst3, r"H", 30004);
+dna!(subst4, r"K", 29974);
+dna!(subst5, r"M", 29979);
+dna!(subst6, r"N", 29959);
+dna!(subst7, r"R", 30012);
+dna!(subst8, r"S", 29994);
+dna!(subst9, r"V", 29996);
+dna!(subst10, r"W", 29984);
+dna!(subst11, r"Y", 29947);


### PR DESCRIPTION
This makes a few touch ups to benchmarks:

1. Add some regex-dna related benchmarks.
2. Change use of RUSTFLAGS="-C target-feature=+ssse3" to
   RUSTFLAGS="-C target-cpu=native".
3. Switch order of parameters to regex-run-one benchmarking tool.