### PR TITLE
Disable all literal optimizations when a pattern is partially anchored.

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -143,9 +143,7 @@ impl Compiler {
         // matching engine itself.
         let mut dotstar_patch = Patch { hole: Hole::None, entry: 0 };
         self.compiled.is_anchored_start = expr.is_anchored_start();
-        self.compiled.has_anchored_start = expr.has_anchored_start();
         self.compiled.is_anchored_end = expr.is_anchored_end();
-        self.compiled.has_anchored_end = expr.has_anchored_end();
         if self.compiled.needs_dotstar() {
             dotstar_patch = try!(self.c_dotstar());
             self.compiled.start = dotstar_patch.entry;
@@ -173,10 +171,6 @@ impl Compiler {
             exprs.iter().all(|e| e.is_anchored_start());
         self.compiled.is_anchored_end =
             exprs.iter().all(|e| e.is_anchored_end());
-        self.compiled.has_anchored_start =
-            exprs.iter().any(|e| e.has_anchored_start());
-        self.compiled.has_anchored_end =
-            exprs.iter().any(|e| e.has_anchored_end());
         let mut dotstar_patch = Patch { hole: Hole::None, entry: 0 };
         if self.compiled.needs_dotstar() {
             dotstar_patch = try!(self.c_dotstar());

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -52,12 +52,6 @@ pub struct Program {
     pub is_anchored_start: bool,
     /// Whether the regex must match at the end of the input.
     pub is_anchored_end: bool,
-    /// Whether the regex has at least one matchable sub-expression that must
-    /// match from the start of the input.
-    pub has_anchored_start: bool,
-    /// Whether the regex has at least one matchable sub-expression that must
-    /// match at the end of the input.
-    pub has_anchored_end: bool,
     /// Whether this program contains a Unicode word boundary instruction.
     pub has_unicode_word_boundary: bool,
     /// A possibly empty machine for very quickly matching prefix literals.
@@ -97,8 +91,6 @@ impl Program {
             is_reverse: false,
             is_anchored_start: false,
             is_anchored_end: false,
-            has_anchored_start: false,
-            has_anchored_end: false,
             has_unicode_word_boundary: false,
             prefixes: LiteralSearcher::empty(),
             dfa_size_limit: 2 * (1<<20),

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -8,6 +8,17 @@ macro_rules! findall {
 
 // Macros for automatically producing tests.
 
+macro_rules! ismatch {
+    ($name:ident, $re:expr, $text:expr, $ismatch:expr) => {
+        #[test]
+        fn $name() {
+            let text = text!($text);
+            let re = regex!($re);
+            assert!($ismatch == re.is_match(text));
+        }
+    };
+}
+
 macro_rules! mat(
     ($name:ident, $re:expr, $text:expr, $($loc:tt)+) => (
         #[test]

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -64,3 +64,7 @@ matiter!(partial_anchor, u!(r"^a|b"), "ba", (0, 1));
 // See: https://github.com/rust-lang-nursery/regex/issues/264
 mat!(ascii_boundary_no_capture, u!(r"(?-u)\B"), "\u{28f3e}", Some((0, 0)));
 mat!(ascii_boundary_capture, u!(r"(?-u)(\B)"), "\u{28f3e}", Some((0, 0)));
+
+// See: https://github.com/rust-lang-nursery/regex/issues/280
+ismatch!(partial_anchor_alternate_begin, u!(r"^a|z"), "yyyyya", false);
+ismatch!(partial_anchor_alternate_end, u!(r"a$|z"), "ayyyyy", false);


### PR DESCRIPTION
When a pattern is partially anchored and literal prefixes are detected,
we would scan for those prefixes like normal. On a match, we'd verify
whether the text starting at that prefix matched the rest of the regex.
This process doesn't work that well for partially anchored regexes, since
the prefix match presupposes that the regex is allowed to match at that
position. But if, say, a regex like `^z|a` finds a `z` in the middle of
the string, then it has lost the fact that `z` needs to appear at the
beginning of the string, and can therefore falsely report a match.

We could spend some effort and make this case work, but the literal
optimizer is already too complex. We need to simplify it to make future
optimizations like this possible.

Fixes #280.