### PR TITLE
Capi capture names

### DIFF
--- a/regex-capi/Cargo.toml
+++ b/regex-capi/Cargo.toml
@@ -17,4 +17,4 @@ crate-type = ["staticlib", "dylib"]
 
 [dependencies]
 libc = "0.2"
-regex = { version = "0.1.69", path = ".." }
+regex = { version = "0.1.77", path = ".." }

--- a/regex-capi/ctest/test.c
+++ b/regex-capi/ctest/test.c
@@ -195,6 +195,60 @@ done:
     return passed;
 }
 
+bool test_iter_capture_name(char *expect, char *given) {
+    bool passed = true;
+    if (strcmp(expect, given)) {
+        if (DEBUG) {
+            fprintf(stderr,
+                    "[test_iter_capture_name] expected first capture name '%s' "
+                    "got '%s'\n",
+                    expect, given);
+        }
+        passed = false;
+    }
+    return passed;
+}
+
+bool test_iter_capture_names() {
+    bool passed = true;
+
+    char *name;
+    rure *re = rure_compile_must("(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})");
+    rure_iter_capture_names *it = rure_iter_capture_names_new(re);
+
+    bool result = rure_iter_capture_names_next(it, &name);
+    if (!result) {
+        if (DEBUG) {
+            fprintf(stderr,
+                    "[test_iter_capture_names] expected a second name, but got none\n");
+        }
+        passed = false;
+        goto done;
+    }
+
+    result = rure_iter_capture_names_next(it, &name);
+    passed = test_iter_capture_name("year", name);
+    if (!passed) {
+        goto done;
+    }
+
+    result = rure_iter_capture_names_next(it, &name);
+    passed = test_iter_capture_name("month", name);
+    if (!passed) {
+        goto done;
+    }
+
+    result = rure_iter_capture_names_next(it, &name);
+    passed = test_iter_capture_name("day", name);
+    if (!passed) {
+        goto done;
+    }
+done:
+    rure_iter_capture_names_free(it);
+    rure_free(re);
+    return passed;
+}
+
 /*
  * This tests whether we can set the flags correctly. In this case, we disable
  * all flags, which includes disabling Unicode mode. When we disable Unicode
@@ -294,6 +348,7 @@ int main() {
     run_test(test_find, "test_find", &passed);
     run_test(test_captures, "test_captures", &passed);
     run_test(test_iter, "test_iter", &passed);
+    run_test(test_iter_capture_names, "test_iter_capture_names", &passed);
     run_test(test_flags, "test_flags", &passed);
     run_test(test_compile_error, "test_compile_error", &passed);
     run_test(test_compile_error_size_limit, "test_compile_error_size_limit",

--- a/regex-capi/include/rure.h
+++ b/regex-capi/include/rure.h
@@ -99,6 +99,17 @@ typedef struct rure_captures rure_captures;
 typedef struct rure_iter rure_iter;
 
 /*
+ * rure_iter_capture_names is an iterator over the list of capture group names
+ * in this particular rure.
+ *
+ * An rure_iter_capture_names value may not outlive its corresponding rure,
+ * and should be freed before its corresponding rure is freed.
+ *
+ * It is not safe to use from multiple threads simultaneously.
+ */
+typedef struct rure_iter_capture_names rure_iter_capture_names;
+
+/*
  * rure_error is an error that caused compilation to fail.
  *
  * Most errors are syntax errors but an error can be returned if the compiled
@@ -267,6 +278,28 @@ bool rure_shortest_match(rure *re, const uint8_t *haystack, size_t length,
 int32_t rure_capture_name_index(rure *re, const char *name);
 
 /*
+ * rure_iter_capture_names_new creates a new capture_names iterator.
+ *
+ * An iterator will report all successive capture group names of re.
+ */
+rure_iter_capture_names *rure_iter_capture_names_new(rure *re);
+
+/*
+ * rure_iter_capture_names_free frees the iterator given.
+ *
+ * It must be called at most once.
+ */
+void rure_iter_capture_names_free(rure_iter_capture_names *it);
+
+/*
+ * rure_iter_capture_names_next advances the iterator and returns true
+ * if and only if another capture group name exists.
+ *
+ * The value of the capture group name is written to the provided pointer.
+ */
+bool rure_iter_capture_names_next(rure_iter_capture_names *it, char **name);
+
+/*
  * rure_iter_new creates a new iterator.
  *
  * An iterator will report all successive non-overlapping matches of re.
@@ -305,7 +338,7 @@ bool rure_iter_next(rure_iter *it, const uint8_t *haystack, size_t length,
                     rure_match *match);
 
 /*
- * rure_iter_next advances the iterator and returns true if and only if a
+ * rure_iter_next_captures advances the iterator and returns true if and only if a
  * match was found. If a match is found, then all of its capture locations are
  * stored in the captures pointer given.
  *


### PR DESCRIPTION
Refs #279.

This isn't ready, but I need some help. I'm stumped by how Rust is handling strings. In my tests with these changes, I see this when using the API:
```
Entering rure_iter_capture_names_next
Iterator last_index: 0
capture_names length: 1
last: 1
Selected name: last
CString cast: 'last'
Entering rure_iter_capture_names_next
Iterator last_index: 1
capture_names length: 1
> /home/dblewett/.virtualenvs/rure/site-packages/rure/regex.py(172)find_captures()
-> match = ffi.new('rure_match *')
(Pdb) all_names
['l          ']
```

I'm not sure if this implementation is correct and the Python FFI is not working, or if the implementation is flawed. What I get back from each call to `rure_iter_next_captures` is either an empty string (when using `ffi.new('char[]', [])`), a single character (when using `ffi.new('char[]', '')`), or a single character followed by padding (when using `ffi.new('char[]', ' ' * 20)`).