### PR TITLE
Fix invariant in comment

### DIFF
--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -257,7 +257,7 @@ pub struct ClassRange {
 
     /// The end character of the range.
     ///
-    /// This must be greater than or equal to `end`.
+    /// This must be greater than or equal to `start`.
     pub end: char,
 }
 


### PR DESCRIPTION
`(end >= end)` is trivial, `(end >= start)` is likely intended.