### PR TITLE
Add RegexSet functionality to C API

### DIFF
--- a/regex-capi/README.md
+++ b/regex-capi/README.md
@@ -99,7 +99,5 @@ There are a few things missing from the C API that are present in the Rust API.
 There's no particular (known) reason why they don't, they just haven't been
 implemented yet.
 
-* RegexSet, which permits matching multiple regular expressions simultaneously
-  in a single linear time search.
 * Splitting a string by a regex.
 * Replacing regex matches in a string with some other text.

--- a/regex-capi/ctest/test.c
+++ b/regex-capi/ctest/test.c
@@ -346,7 +346,10 @@ bool test_regex_set_matches() {
     rure_error *err = rure_error_new();
     rure_set *re = rure_compile_set((const uint8_t **) patterns,
                                     patterns_lengths,
-                                    PAT_COUNT, err);
+                                    PAT_COUNT,
+                                    0,
+                                    NULL,
+                                    err);
     if (re == NULL) {
         passed = false;
         goto done2;
@@ -357,18 +360,18 @@ bool test_regex_set_matches() {
         goto done1;
     }
 
-    if (!rure_set_is_match(re, (const uint8_t *) "foobar", 6)) {
+    if (!rure_set_is_match(re, (const uint8_t *) "foobar", 6, 0)) {
         passed = false;
         goto done1;
     }
 
-    if (rure_set_is_match(re, (const uint8_t *) "", 0)) {
+    if (rure_set_is_match(re, (const uint8_t *) "", 0, 0)) {
         passed = false;
         goto done1;
     }
 
     bool matches[PAT_COUNT];
-    if (!rure_set_matches(re, (const uint8_t *) "foobar", 6, matches)) {
+    if (!rure_set_matches(re, (const uint8_t *) "foobar", 6, 0, matches)) {
         passed = false;
         goto done1;
     }

--- a/regex-capi/ctest/test.c
+++ b/regex-capi/ctest/test.c
@@ -352,6 +352,11 @@ bool test_regex_set_matches() {
         goto done2;
     }
 
+    if (rure_set_len(re) != PAT_COUNT) {
+        passed = false;
+        goto done1;
+    }
+
     if (!rure_set_is_match(re, (const uint8_t *) "foobar", 6)) {
         passed = false;
         goto done1;

--- a/regex-capi/include/rure.h
+++ b/regex-capi/include/rure.h
@@ -468,7 +468,10 @@ void rure_options_dfa_size_limit(rure_options *options, size_t limit);
  */
 rure_set *rure_compile_set(const uint8_t **patterns,
                            const size_t *patterns_lengths,
-                           size_t patterns_count, rure_error *error);
+                           size_t patterns_count,
+                           uint32_t flags,
+                           rure_options *options,
+                           rure_error *error);
 
 /*
  * rure_set_free frees the given compiled regular expression set.
@@ -486,7 +489,8 @@ void rure_set_free(rure_set *re);
  * useful. UTF-8 is even more useful. Other text encodings aren't supported.
  * length should be the number of bytes in haystack.
  */
-bool rure_set_is_match(rure_set *re, const uint8_t *haystack, size_t length);
+bool rure_set_is_match(rure_set *re, const uint8_t *haystack, size_t length,
+                       size_t start);
 
 /*
  * rure_set_matches compares each regex in the set against the haystack and
@@ -507,7 +511,7 @@ bool rure_set_is_match(rure_set *re, const uint8_t *haystack, size_t length);
  * caring which, use rure_set_is_match.
  */
 bool rure_set_matches(rure_set *re, const uint8_t *haystack, size_t length,
-                      bool *matches);
+                      size_t start, bool *matches);
 
 /*
  * rure_set_len returns the number of patterns rure_set was compiled with.

--- a/regex-capi/include/rure.h
+++ b/regex-capi/include/rure.h
@@ -473,7 +473,7 @@ rure_set *rure_compile_set(const uint8_t **patterns,
 /*
  * rure_set_free frees the given compiled regular expression set.
  *
- * This must be called at most once.
+ * This must be called at most once for any rure_set.
  */
 void rure_set_free(rure_set *re);
 
@@ -490,8 +490,10 @@ bool rure_set_is_match(rure_set *re, const uint8_t *haystack, size_t length);
 
 /*
  * rure_set_matches compares each regex in the set against the haystack and
- * returns an array of bools which correspond to if a match was found for
- * the specified regex.
+ * modifies matches with the match result of each pattern. Match results are
+ * ordered in the same way as the rure_set was compiled. For example,
+ * index 0 of matches corresponds to the first pattern passed to
+ * `rure_compile_set`.
  *
  * haystack may contain arbitrary bytes, but ASCII compatible text is more
  * useful. UTF-8 is even more useful. Other text encodings aren't supported.
@@ -505,7 +507,12 @@ bool rure_set_is_match(rure_set *re, const uint8_t *haystack, size_t length);
  * caring which, use rure_set_is_match.
  */
 bool rure_set_matches(rure_set *re, const uint8_t *haystack, size_t length,
-                      const bool *matches);
+                      bool *matches);
+
+/*
+ * rure_set_len returns the number of patterns rure_set was compiled with.
+ */
+size_t rure_set_len(rure_set *re);
 
 /*
  * rure_error_new allocates space for an error.

--- a/regex-capi/include/rure.h
+++ b/regex-capi/include/rure.h
@@ -462,6 +462,13 @@ void rure_options_dfa_size_limit(rure_options *options, size_t limit);
  * The number of patterns to compile is specified by patterns_count. patterns
  * must contain at least this many entries.
  *
+ * flags is a bitfield. Valid values are constants declared with prefix
+ * RURE_FLAG_.
+ *
+ * options contains non-flag configuration settings. If it's NULL, default
+ * settings are used. options may be freed immediately after a call to
+ * rure_compile.
+ *
  * error is set if there was a problem compiling the pattern.
  *
  * The compiled expression set returned may be used from multiple threads.
@@ -488,6 +495,12 @@ void rure_set_free(rure_set *re);
  * haystack may contain arbitrary bytes, but ASCII compatible text is more
  * useful. UTF-8 is even more useful. Other text encodings aren't supported.
  * length should be the number of bytes in haystack.
+ *
+ * start is the position at which to start searching. Note that setting the
+ * start position is distinct from incrementing the pointer, since the regex
+ * engine may look at bytes before the start position to determine match
+ * information. For example, if the start position is greater than 0, then the
+ * \A ("begin text") anchor can never match.
  */
 bool rure_set_is_match(rure_set *re, const uint8_t *haystack, size_t length,
                        size_t start);
@@ -502,6 +515,12 @@ bool rure_set_is_match(rure_set *re, const uint8_t *haystack, size_t length,
  * haystack may contain arbitrary bytes, but ASCII compatible text is more
  * useful. UTF-8 is even more useful. Other text encodings aren't supported.
  * length should be the number of bytes in haystack.
+ *
+ * start is the position at which to start searching. Note that setting the
+ * start position is distinct from incrementing the pointer, since the regex
+ * engine may look at bytes before the start position to determine match
+ * information. For example, if the start position is greater than 0, then the
+ * \A ("begin text") anchor can never match.
  *
  * matches must be greater than or equal to the number of patterns the
  * rure_set was compiled with.

--- a/regex-capi/src/rure.rs
+++ b/regex-capi/src/rure.rs
@@ -1,6 +1,7 @@
 use ::error::{Error, ErrorKind};
 
 use ::regex::bytes;
+use ::regex::internal::{Exec, ExecBuilder, RegexOptions};
 use ::libc::{c_char, size_t};
 
 use ::std::collections::HashMap;
@@ -469,6 +470,8 @@ ffi_fn! {
         patterns: *const *const u8,
         patterns_lengths: *const size_t,
         patterns_count: size_t,
+        flags: u32,
+        options: *const Options,
         error: *mut Error
     ) -> *const RegexSet {
         let (raw_pats, raw_patsl) = unsafe {
@@ -525,7 +528,8 @@ ffi_fn! {
     fn rure_set_is_match(
         re: *const RegexSet,
         haystack: *const u8,
-        len: size_t
+        len: size_t,
+        start: size_t
     ) -> bool {
         let re = unsafe { &*re };
         let haystack = unsafe { slice::from_raw_parts(haystack, len) };
@@ -538,6 +542,7 @@ ffi_fn! {
         re: *const RegexSet,
         haystack: *const u8,
         len: size_t,
+        start: size_t,
         matches: *mut bool
     ) -> bool {
         let re = unsafe { &*re };

--- a/regex-capi/src/rure.rs
+++ b/regex-capi/src/rure.rs
@@ -554,3 +554,10 @@ ffi_fn! {
         matches.matched_any()
     }
 }
+
+ffi_fn! {
+    fn rure_set_len(re: *const RegexSet) -> size_t {
+        let re = unsafe { &*re };
+        re.len()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,4 +603,5 @@ pub mod internal {
     pub use prog::{Program, Inst, EmptyLook, InstRanges};
     pub use re_plugin::Plugin;
     pub use re_unicode::_Regex;
+    pub use re_builder::RegexOptions;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,5 +603,6 @@ pub mod internal {
     pub use prog::{Program, Inst, EmptyLook, InstRanges};
     pub use re_plugin::Plugin;
     pub use re_unicode::_Regex;
+    pub use re_trait::RegularExpression;
     pub use re_builder::RegexOptions;
 }

--- a/src/re_builder.rs
+++ b/src/re_builder.rs
@@ -7,10 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![allow(missing_docs)]
 
 /// The set of user configurable options for compiling zero or more regexes.
 #[derive(Clone, Debug)]
+#[allow(missing_docs)]
 pub struct RegexOptions {
     pub pats: Vec<String>,
     pub size_limit: usize,

--- a/src/re_builder.rs
+++ b/src/re_builder.rs
@@ -7,6 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![allow(missing_docs)]
 
 /// The set of user configurable options for compiling zero or more regexes.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
These functions implement a C interface to the RegexSet api.

Some notes:
- These do not include start offsets as the standard regex functions
  do. The reason being is down to how these are implemented in the core
  regex crate. The RegexSet api does not expose a public is_match_at
  whilst the Regex api does. I would actually like to change this if possible
  as the inconsistency this makes between `rure` and `rure_set` types is
  not great.
- This only tests a complete compile/match mainly for sanity. One or
  two more tests targeting the specific areas would be preferred.
- Set matches take a mutable array to fill with results. This is more
  C-like and allows the caller to manage the memory on the stack if
  they want.

Wanted to make a request before targeting these changes to clarify.
