### PR TITLE
Fix a bug in uambiguous prefixes.

### DIFF
--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -68,3 +68,6 @@ mat!(ascii_boundary_capture, u!(r"(?-u)(\B)"), "\u{28f3e}", Some((0, 0)));
 // See: https://github.com/rust-lang-nursery/regex/issues/280
 ismatch!(partial_anchor_alternate_begin, u!(r"^a|z"), "yyyyya", false);
 ismatch!(partial_anchor_alternate_end, u!(r"a$|z"), "ayyyyy", false);
+
+// See: https://github.com/rust-lang-nursery/regex/issues/289
+mat!(lits_unambiguous, u!(r"(ABC|CDA|BC)X"), "CDAX", Some((0, 4)));


### PR DESCRIPTION
Specifically, given the strings ABCX, CDAX and BCX, it was reporting
the unambiguous set as A, BCX and CDAX, which is wrong since A is a
substring of CDAX.

unambiguous_prefixes is now quite a bit of a mess, but so is the rest
of the literal extraction code. The only thing it has going for it is
a massive test suite.

Fixes #289