### PR TITLE
dylib -> cdylib

### DIFF
--- a/regex-capi/Cargo.toml
+++ b/regex-capi/Cargo.toml
@@ -13,7 +13,7 @@ A C API for Rust's regular expression library.
 
 [lib]
 name = "rure"
-crate-type = ["staticlib", "dylib"]
+crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
The newer cdylib crate type is specifically for the "expose to other languages" case.