### PR TITLE
Update to thread_local 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ aho-corasick = "0.5.3"
 # For skipping along search text quickly when a leading byte is known.
 memchr = "0.1.9"
 # For managing regex caches quickly across multiple threads.
-thread_local = "0.2.4"
+thread_local = "0.3"
 # For parsing regular expressions.
 regex-syntax = { path = "regex-syntax", version = "0.3.8" }
 # For accelerating text search.


### PR DESCRIPTION
This reduces the number of versions of thread_local and thread-id present in many application crates.

This also changes the minimum Cargo version required, so it shouldn't go in until that makes sense.